### PR TITLE
Add sandbox user provisioning roles

### DIFF
--- a/roles/ocp4_workload_ocpsandbox_argocd_user/README.md
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/README.md
@@ -1,0 +1,71 @@
+# ocp4_workload_ocpsandbox_argocd_user
+
+User provisioning role for OcpSandbox clusters with ArgoCD (OpenShift GitOps).
+
+## When to Use
+
+Use this role in any OcpSandbox catalog item where students need their own ArgoCD AppProject for GitOps deployments. Typically runs after `ocp4_workload_ocpsandbox_keycloak_user` (which sets up cluster connectivity).
+
+## Why It Exists
+
+OpenShift GitOps is deployed at the cluster level with no per-user access. This role creates an AppProject scoped to the student's namespaces, allowing ArgoCD ApplicationSets to deploy resources only into namespaces ending with `-{username}`.
+
+## How to Use
+
+### In AgV catalog (`common.yaml`)
+
+```yaml
+# Provision order
+workloads:
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_keycloak_user
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_argocd_user
+# ... other workloads that create ApplicationSets in this project
+
+# Destroy order (reverse) -- argocd_user cleans up ApplicationSets + Applications + AppProject
+remove_workloads:
+# ... other workloads
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_argocd_user
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_keycloak_user
+
+# Variables
+ocp4_workload_ocpsandbox_argocd_user_username: "user1-{{ guid }}"
+ocp4_workload_ocpsandbox_argocd_user_cluster_resource_whitelist:
+- group: ""
+  kind: Namespace
+- group: rbac.authorization.k8s.io
+  kind: ClusterRole
+- group: rbac.authorization.k8s.io
+  kind: ClusterRoleBinding
+```
+
+The role uses `ACTION` variable (set automatically by AgnosticD): `provision` runs `workload.yml`, `destroy` runs `remove_workload.yml`.
+
+### Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `_openshift_api_url` | `{{ sandbox_openshift_api_url }}` | Cluster API URL |
+| `_openshift_api_token` | `{{ cluster_admin_agnosticd_sa_token }}` | SA token |
+| `_username` | `user1-{{ guid }}` | Username for the AppProject |
+| `_namespace` | `openshift-gitops` | ArgoCD namespace |
+| `_project_prefix` | `appproject-` | Prefix for AppProject name |
+| `_cluster_resource_whitelist` | `[]` | Cluster-scoped resources the project can manage |
+
+All variables are prefixed with `ocp4_workload_ocpsandbox_argocd_user`.
+
+### What It Creates
+
+- AppProject `{prefix}{username}` in `openshift-gitops` namespace
+- Destinations: `*-{username}` (all namespaces ending with the username)
+- sourceRepos: `*` (all repos allowed)
+- User role with full application RBAC within the project
+- Group binding for `{username}` (Keycloak group mapping)
+
+### Destroy
+
+Cleanup order: ApplicationSets -> Applications -> wait for deletion -> AppProject.
+
+## Prerequisites
+
+- OpenShift GitOps deployed via `ocp4_workload_openshift_gitops` (cluster provisioning)
+- `ocp4_workload_ocpsandbox_keycloak_user` must run first (for cluster connectivity)

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/defaults/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# Cluster connection (from sandbox)
+ocp4_workload_ocpsandbox_argocd_user_openshift_api_url: "{{ sandbox_openshift_api_url }}"
+ocp4_workload_ocpsandbox_argocd_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token }}"
+
+# User to create AppProject for -- defaults to userX-GUID format
+ocp4_workload_ocpsandbox_argocd_user_username: "user1-{{ guid }}"
+
+# ArgoCD configuration
+ocp4_workload_ocpsandbox_argocd_user_namespace: openshift-gitops
+ocp4_workload_ocpsandbox_argocd_user_project_prefix: "appproject-"
+ocp4_workload_ocpsandbox_argocd_user_cluster_resource_whitelist: []
+# Example:
+# - group: ""
+#   kind: Namespace

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/defaults/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/defaults/main.yml
@@ -13,3 +13,11 @@ ocp4_workload_ocpsandbox_argocd_user_cluster_resource_whitelist: []
 # Example:
 # - group: ""
 #   kind: Namespace
+
+# Extra destination namespaces to allow in the AppProject.
+# By default the project allows *-{{ username }}. Use this list
+# to add namespaces that don't match that pattern (e.g. the
+# primary sandbox namespace created by the sandbox API).
+ocp4_workload_ocpsandbox_argocd_user_extra_destinations: []
+# Example:
+# - "sandbox-abc12-agent"

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/defaults/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cluster connection (from sandbox)
 ocp4_workload_ocpsandbox_argocd_user_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-ocp4_workload_ocpsandbox_argocd_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token }}"
+ocp4_workload_ocpsandbox_argocd_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
 
 # User to create AppProject for -- defaults to userX-GUID format
 ocp4_workload_ocpsandbox_argocd_user_username: "user1-{{ guid }}"

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/meta/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_ocpsandbox_argocd_user
+  author: Red Hat, Prakhar Srivastava
+  description: |
+    Per-user ArgoCD AppProject provisioning on shared OCP clusters.
+    Creates AppProject with user RBAC for namespace-scoped deployments.
+    Designed for namespace config with sandbox API pattern.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - argocd
+  - gitops
+dependencies: []

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/tasks/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks: remove_workload.yml

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/tasks/remove_workload.yml
@@ -1,0 +1,95 @@
+---
+# Thorough ArgoCD cleanup for long-running shared clusters.
+# Order: ApplicationSets -> Applications -> wait -> AppProject
+
+- name: Get all ApplicationSets in ArgoCD namespace
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: argoproj.io/v1alpha1
+    kind: ApplicationSet
+    namespace: "{{ ocp4_workload_ocpsandbox_argocd_user_namespace }}"
+  register: r_argocd_appsets
+
+- name: Remove ApplicationSets belonging to user's project
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_token }}"
+    validate_certs: false
+    state: absent
+    api_version: argoproj.io/v1alpha1
+    kind: ApplicationSet
+    name: "{{ appset_item.metadata.name }}"
+    namespace: "{{ ocp4_workload_ocpsandbox_argocd_user_namespace }}"
+  loop: >-
+    {{ r_argocd_appsets.resources
+       | selectattr('spec.template.spec.project', 'defined')
+       | selectattr('spec.template.spec.project', 'equalto',
+           ocp4_workload_ocpsandbox_argocd_user_project_prefix ~ ocp4_workload_ocpsandbox_argocd_user_username)
+       | list }}
+  loop_control:
+    loop_var: appset_item
+    label: "{{ appset_item.metadata.name }}"
+  ignore_errors: true
+
+- name: Get all Applications in ArgoCD namespace
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    namespace: "{{ ocp4_workload_ocpsandbox_argocd_user_namespace }}"
+  register: r_argocd_apps
+
+- name: Remove Applications belonging to user's project
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_token }}"
+    validate_certs: false
+    state: absent
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ app_item.metadata.name }}"
+    namespace: "{{ ocp4_workload_ocpsandbox_argocd_user_namespace }}"
+  loop: >-
+    {{ r_argocd_apps.resources
+       | selectattr('spec.project', 'equalto',
+           ocp4_workload_ocpsandbox_argocd_user_project_prefix ~ ocp4_workload_ocpsandbox_argocd_user_username)
+       | list }}
+  loop_control:
+    loop_var: app_item
+    label: "{{ app_item.metadata.name }}"
+  ignore_errors: true
+
+- name: Wait for Applications to be fully removed
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    namespace: "{{ ocp4_workload_ocpsandbox_argocd_user_namespace }}"
+  register: r_remaining_apps
+  retries: 30
+  delay: 10
+  until: >-
+    r_remaining_apps.resources
+    | selectattr('spec.project', 'equalto',
+        ocp4_workload_ocpsandbox_argocd_user_project_prefix ~ ocp4_workload_ocpsandbox_argocd_user_username)
+    | list
+    | length == 0
+  ignore_errors: true
+
+- name: Delete ArgoCD AppProject
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_token }}"
+    validate_certs: false
+    state: absent
+    api_version: argoproj.io/v1alpha1
+    kind: AppProject
+    name: "{{ ocp4_workload_ocpsandbox_argocd_user_project_prefix }}{{ ocp4_workload_ocpsandbox_argocd_user_username }}"
+    namespace: "{{ ocp4_workload_ocpsandbox_argocd_user_namespace }}"
+  ignore_errors: true

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/tasks/workload.yml
@@ -1,0 +1,13 @@
+---
+- name: Create ArgoCD AppProject for user
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_argocd_user_openshift_api_token }}"
+    validate_certs: false
+    state: present
+    template: appproject-user.yaml.j2
+
+- name: Save ArgoCD information
+  agnosticd.core.agnosticd_user_info:
+    data:
+      argocd_project: "{{ ocp4_workload_ocpsandbox_argocd_user_project_prefix }}{{ ocp4_workload_ocpsandbox_argocd_user_username }}"

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/templates/appproject-user.yaml.j2
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/templates/appproject-user.yaml.j2
@@ -11,6 +11,10 @@ spec:
   destinations:
   - namespace: "*-{{ ocp4_workload_ocpsandbox_argocd_user_username }}"
     server: https://kubernetes.default.svc
+{% for ns in ocp4_workload_ocpsandbox_argocd_user_extra_destinations %}
+  - namespace: "{{ ns }}"
+    server: https://kubernetes.default.svc
+{% endfor %}
   sourceRepos:
   - "*"
   clusterResourceWhitelist:

--- a/roles/ocp4_workload_ocpsandbox_argocd_user/templates/appproject-user.yaml.j2
+++ b/roles/ocp4_workload_ocpsandbox_argocd_user/templates/appproject-user.yaml.j2
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {{ ocp4_workload_ocpsandbox_argocd_user_project_prefix }}{{ ocp4_workload_ocpsandbox_argocd_user_username }}
+  namespace: {{ ocp4_workload_ocpsandbox_argocd_user_namespace }}
+  labels:
+    app.kubernetes.io/managed-by: agnosticd
+spec:
+  description: "Project for {{ ocp4_workload_ocpsandbox_argocd_user_username }}"
+  destinations:
+  - namespace: "*-{{ ocp4_workload_ocpsandbox_argocd_user_username }}"
+    server: https://kubernetes.default.svc
+  sourceRepos:
+  - "*"
+  clusterResourceWhitelist:
+{% for resource in ocp4_workload_ocpsandbox_argocd_user_cluster_resource_whitelist %}
+  - group: "{{ resource.group }}"
+    kind: {{ resource.kind }}
+{% endfor %}
+  roles:
+  - name: user-role
+    description: "Role for {{ ocp4_workload_ocpsandbox_argocd_user_username }}"
+    policies:
+    - >-
+      p, proj:{{ ocp4_workload_ocpsandbox_argocd_user_project_prefix }}{{ ocp4_workload_ocpsandbox_argocd_user_username }}:user-role,
+      applications, *,
+      {{ ocp4_workload_ocpsandbox_argocd_user_project_prefix }}{{ ocp4_workload_ocpsandbox_argocd_user_username }}/*,
+      allow
+    groups:
+    - "{{ ocp4_workload_ocpsandbox_argocd_user_username }}"

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/defaults/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# ------------------------------------------------
+# Gitea instance provisioner for OCP Sandbox model
+# Deploys a per-user Gitea instance via the Gitea operator CR
+# ------------------------------------------------
+
+# Cluster connection (from sandbox)
+ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url: "{{ sandbox_openshift_api_url }}"
+ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
+
+# Namespace where Gitea instance will be deployed
+ocp4_workload_ocpsandbox_gitea_instance_namespace: gitea
+
+# Gitea container image
+ocp4_workload_ocpsandbox_gitea_instance_image: quay.io/rhpds/gitea
+ocp4_workload_ocpsandbox_gitea_instance_image_tag: "1.25.4"
+ocp4_workload_ocpsandbox_gitea_instance_volume_size: 2Gi
+
+# PostgreSQL backend for Gitea
+ocp4_workload_ocpsandbox_gitea_instance_postgresql_image: registry.redhat.io/rhel10/postgresql-16
+ocp4_workload_ocpsandbox_gitea_instance_postgresql_image_tag: latest
+ocp4_workload_ocpsandbox_gitea_instance_postgresql_volume_size: 2Gi
+
+# Gitea admin credentials (set in the Gitea CR)
+ocp4_workload_ocpsandbox_gitea_instance_admin_user: gitea-admin
+ocp4_workload_ocpsandbox_gitea_instance_admin_password: ""

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/meta/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_ocpsandbox_gitea_instance
+  author: Red Hat, Prakhar Srivastava
+  description: |
+    Deploys a per-user Gitea instance via the Gitea operator CR.
+    Waits for readiness and exports gitea_url fact for downstream roles.
+    Designed for namespace config with sandbox API pattern.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - gitea
+dependencies: []

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks: remove_workload.yml

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/remove_workload.yml
@@ -1,11 +1,17 @@
 ---
 # Gitea instance cleanup.
-# The Gitea CR and all resources (Deployment, Service, Route, PVCs)
-# live inside the namespace which is deleted by sandbox API.
-# No explicit cleanup needed here.
+# Delete the namespace (and everything in it) since it was created
+# by this role as fallback when sandbox API didn't create it.
+# If sandbox API created the namespace, it will also try to delete it
+# which is fine -- one of the two deletions will be a no-op.
 
-- name: Gitea instance cleanup handled by sandbox API
-  ansible.builtin.debug:
-    msg: >-
-      Gitea instance in namespace {{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}
-      will be cleaned up when sandbox API deletes the namespace.
+- name: Delete Gitea namespace
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
+    validate_certs: false
+    api_version: v1
+    kind: Namespace
+    name: "{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}"
+    state: absent
+  ignore_errors: true

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/remove_workload.yml
@@ -1,17 +1,4 @@
 ---
 # Gitea instance cleanup.
-# Delete the namespace (and everything in it) since it was created
-# by this role as fallback when sandbox API didn't create it.
-# If sandbox API created the namespace, it will also try to delete it
-# which is fine -- one of the two deletions will be a no-op.
-
-- name: Delete Gitea namespace
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
-    validate_certs: false
-    api_version: v1
-    kind: Namespace
-    name: "{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}"
-    state: absent
-  ignore_errors: true
+# Namespace is managed by the sandbox API (created and deleted automatically).
+# No explicit namespace deletion needed here.

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/remove_workload.yml
@@ -1,0 +1,11 @@
+---
+# Gitea instance cleanup.
+# The Gitea CR and all resources (Deployment, Service, Route, PVCs)
+# live inside the namespace which is deleted by sandbox API.
+# No explicit cleanup needed here.
+
+- name: Gitea instance cleanup handled by sandbox API
+  ansible.builtin.debug:
+    msg: >-
+      Gitea instance in namespace {{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}
+      will be cleaned up when sandbox API deletes the namespace.

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
@@ -1,5 +1,20 @@
 ---
 # ==================================================================
+# Ensure namespace exists (fallback if sandbox API didn't create it)
+# ==================================================================
+- name: Ensure Gitea namespace exists
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
+    validate_certs: false
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}"
+
+# ==================================================================
 # Deploy per-user Gitea instance via Gitea operator CR
 # ==================================================================
 - name: Deploy Gitea instance CR

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
@@ -1,0 +1,79 @@
+---
+# ==================================================================
+# Deploy per-user Gitea instance via Gitea operator CR
+# Namespace is created by sandbox API
+# ==================================================================
+- name: Deploy Gitea instance CR
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
+    validate_certs: false
+    state: present
+    definition:
+      apiVersion: pfe.rhpds.com/v1
+      kind: Gitea
+      metadata:
+        name: gitea
+        namespace: "{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}"
+      spec:
+        giteaImage: "{{ ocp4_workload_ocpsandbox_gitea_instance_image }}"
+        giteaImageTag: "{{ ocp4_workload_ocpsandbox_gitea_instance_image_tag }}"
+        giteaVolumeSize: "{{ ocp4_workload_ocpsandbox_gitea_instance_volume_size }}"
+        postgresqlImage: "{{ ocp4_workload_ocpsandbox_gitea_instance_postgresql_image }}"
+        postgresqlImageTag: "{{ ocp4_workload_ocpsandbox_gitea_instance_postgresql_image_tag }}"
+        postgresqlVolumeSize: "{{ ocp4_workload_ocpsandbox_gitea_instance_postgresql_volume_size }}"
+        giteaSsl: true
+        giteaAdminUser: "{{ ocp4_workload_ocpsandbox_gitea_instance_admin_user }}"
+        giteaAdminPassword: "{{ ocp4_workload_ocpsandbox_gitea_instance_admin_password }}"
+        giteaAdminEmail: "admin@demo.redhat.com"
+        giteaDisableRegistration: true
+        giteaEnableCaptcha: false
+        giteaAllowCreateOrganization: true
+        giteaRegisterEmailConfirm: false
+        giteaEnableNotifyMail: false
+
+# ------------------------------------------------------------------
+# Wait for Gitea to become ready
+# ------------------------------------------------------------------
+- name: Wait for Gitea route to be available
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
+    validate_certs: false
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: "{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}"
+    label_selectors:
+    - app=gitea
+  register: r_gitea_route
+  retries: 60
+  delay: 10
+  until: r_gitea_route.resources | length > 0
+
+- name: Set Gitea URL facts for downstream roles
+  ansible.builtin.set_fact:
+    gitea_url: "https://{{ r_gitea_route.resources[0].spec.host }}"
+    gitea_internal_url: >-
+      http://gitea.{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}.svc.cluster.local:3000
+
+- name: Wait for Gitea admin API to be ready
+  ansible.builtin.uri:
+    url: "{{ gitea_url }}/api/v1/admin/users"
+    method: GET
+    user: "{{ ocp4_workload_ocpsandbox_gitea_instance_admin_user }}"
+    password: "{{ ocp4_workload_ocpsandbox_gitea_instance_admin_password }}"
+    force_basic_auth: true
+    validate_certs: true
+    status_code: [200]
+  register: r_gitea_ready
+  retries: 30
+  delay: 10
+  until: r_gitea_ready.status | default(0) == 200
+
+# ------------------------------------------------------------------
+# Export information for downstream roles and showroom
+# ------------------------------------------------------------------
+- name: Save Gitea instance information
+  agnosticd.core.agnosticd_user_info:
+    data:
+      gitea_url: "{{ gitea_url }}"

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
@@ -1,21 +1,7 @@
 ---
 # ==================================================================
-# Ensure namespace exists (fallback if sandbox API didn't create it)
-# ==================================================================
-- name: Ensure Gitea namespace exists
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}"
-
-# ==================================================================
 # Deploy per-user Gitea instance via Gitea operator CR
+# Namespace is created by the sandbox API (cluster_condition: same(cluster))
 # ==================================================================
 - name: Deploy Gitea instance CR
   kubernetes.core.k8s:

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
@@ -1,39 +1,9 @@
 ---
 # ==================================================================
-# Discover the gitea namespace created by the sandbox API.
-# The sandbox API labels all namespaces with 'guid' and
-# 'created-by=sandbox-api'. The gitea namespace name ends with '-gitea'.
-# This avoids relying on the 'var' key in common.yaml (not yet
-# implemented in sandbox API / AgnosticD).
-# ==================================================================
-- name: Find sandbox-created gitea namespace
-  kubernetes.core.k8s_info:
-    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
-    validate_certs: false
-    api_version: v1
-    kind: Namespace
-    label_selectors:
-    - "created-by=sandbox-api"
-    - "guid={{ sandbox_openshift_namespace | regex_replace('^sandbox-([^-]+)-.*', '\\1') }}"
-  register: r_sandbox_namespaces
-
-- name: Set gitea namespace from discovered sandbox namespace
-  ansible.builtin.set_fact:
-    ocp4_workload_ocpsandbox_gitea_instance_namespace: >-
-      {{ r_sandbox_namespaces.resources
-         | map(attribute='metadata.name')
-         | select('match', '.*-[0-9]+-gitea$')
-         | list | first }}
-    ocp4_workload_ocpsandbox_gitea_user_namespace: >-
-      {{ r_sandbox_namespaces.resources
-         | map(attribute='metadata.name')
-         | select('match', '.*-[0-9]+-gitea$')
-         | list | first }}
-
-# ==================================================================
-# Deploy per-user Gitea instance via Gitea operator CR
-# Namespace is created by the sandbox API (cluster_condition: same(cluster))
+# Deploy per-user Gitea instance via Gitea operator CR.
+# Namespace is created and named by the sandbox API (var: gitea entry).
+# ocp4_workload_ocpsandbox_gitea_instance_namespace is set in common.yaml
+# via {{ gitea.sandbox_openshift_namespace }} from the sandbox API var dict.
 # ==================================================================
 - name: Deploy Gitea instance CR
   kubernetes.core.k8s:

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
@@ -1,20 +1,5 @@
 ---
 # ==================================================================
-# Ensure namespace exists (fallback if sandbox API didn't create it)
-# ==================================================================
-- name: Ensure Gitea namespace exists
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}"
-
-# ==================================================================
 # Deploy per-user Gitea instance via Gitea operator CR
 # ==================================================================
 - name: Deploy Gitea instance CR

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
@@ -1,7 +1,21 @@
 ---
 # ==================================================================
+# Ensure namespace exists (fallback if sandbox API didn't create it)
+# ==================================================================
+- name: Ensure Gitea namespace exists
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
+    validate_certs: false
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ocp4_workload_ocpsandbox_gitea_instance_namespace }}"
+
+# ==================================================================
 # Deploy per-user Gitea instance via Gitea operator CR
-# Namespace is created by sandbox API
 # ==================================================================
 - name: Deploy Gitea instance CR
   kubernetes.core.k8s:

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
@@ -1,5 +1,32 @@
 ---
 # ==================================================================
+# Discover the gitea namespace created by the sandbox API.
+# The sandbox API labels all namespaces with 'guid' and
+# 'created-by=sandbox-api'. The gitea namespace name ends with '-gitea'.
+# This avoids relying on the 'var' key in common.yaml (not yet
+# implemented in sandbox API / AgnosticD).
+# ==================================================================
+- name: Find sandbox-created gitea namespace
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_gitea_instance_openshift_api_token }}"
+    validate_certs: false
+    api_version: v1
+    kind: Namespace
+    label_selectors:
+    - "created-by=sandbox-api"
+    - "guid={{ guid }}"
+  register: r_sandbox_namespaces
+
+- name: Set gitea namespace from discovered sandbox namespace
+  ansible.builtin.set_fact:
+    ocp4_workload_ocpsandbox_gitea_instance_namespace: >-
+      {{ r_sandbox_namespaces.resources
+         | map(attribute='metadata.name')
+         | select('match', '.*-gitea$')
+         | list | first }}
+
+# ==================================================================
 # Deploy per-user Gitea instance via Gitea operator CR
 # Namespace is created by the sandbox API (cluster_condition: same(cluster))
 # ==================================================================

--- a/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_instance/tasks/workload.yml
@@ -15,7 +15,7 @@
     kind: Namespace
     label_selectors:
     - "created-by=sandbox-api"
-    - "guid={{ guid }}"
+    - "guid={{ sandbox_openshift_namespace | regex_replace('^sandbox-([^-]+)-.*', '\\1') }}"
   register: r_sandbox_namespaces
 
 - name: Set gitea namespace from discovered sandbox namespace
@@ -23,7 +23,12 @@
     ocp4_workload_ocpsandbox_gitea_instance_namespace: >-
       {{ r_sandbox_namespaces.resources
          | map(attribute='metadata.name')
-         | select('match', '.*-gitea$')
+         | select('match', '.*-[0-9]+-gitea$')
+         | list | first }}
+    ocp4_workload_ocpsandbox_gitea_user_namespace: >-
+      {{ r_sandbox_namespaces.resources
+         | map(attribute='metadata.name')
+         | select('match', '.*-[0-9]+-gitea$')
          | list | first }}
 
 # ==================================================================

--- a/roles/ocp4_workload_ocpsandbox_gitea_user/README.md
+++ b/roles/ocp4_workload_ocpsandbox_gitea_user/README.md
@@ -1,0 +1,70 @@
+# ocp4_workload_ocpsandbox_gitea_user
+
+User provisioning role for OcpSandbox clusters with Gitea.
+
+## When to Use
+
+Use this role in any OcpSandbox catalog item where students need their own Gitea user account and repositories. Typically runs after `ocp4_workload_ocpsandbox_keycloak_user` (which sets up cluster connectivity).
+
+## Why It Exists
+
+The Gitea operator deploys a shared Gitea instance with an admin account, but no per-user accounts. This role creates individual student accounts via the Gitea REST API and optionally migrates (forks) repositories from GitHub into each student's account.
+
+## How to Use
+
+### In AgV catalog (`common.yaml`)
+
+```yaml
+# Provision order
+workloads:
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_keycloak_user
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_gitea_user
+# ... other workloads
+
+# Destroy order (reverse)
+remove_workloads:
+# ... other workloads
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_gitea_user
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_keycloak_user
+
+# Variables
+ocp4_workload_ocpsandbox_gitea_user_username: "user1-{{ guid }}"
+ocp4_workload_ocpsandbox_gitea_user_password: "{{ common_password }}"
+ocp4_workload_ocpsandbox_gitea_user_repositories:
+- name: mcp
+  repo: https://github.com/rhpds/ocpsandbox-mcp-with-openshift-gitops
+  private: false
+```
+
+The role uses `ACTION` variable (set automatically by AgnosticD): `provision` runs `workload.yml`, `destroy` runs `remove_workload.yml`.
+
+### Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `_openshift_api_url` | `{{ sandbox_openshift_api_url }}` | Cluster API URL |
+| `_openshift_api_token` | `{{ cluster_admin_agnosticd_sa_token }}` | SA token |
+| `_username` | `user1-{{ guid }}` | Gitea username to create |
+| `_password` | (required) | Password for the user |
+| `_namespace` | `gitea` | Namespace where Gitea is deployed |
+| `_admin_user` | (auto-discovered) | Gitea admin username (from Gitea CR) |
+| `_admin_password` | (auto-discovered) | Gitea admin password (from Gitea CR) |
+| `_repositories` | `[]` | List of repos to migrate for the user |
+
+All variables are prefixed with `ocp4_workload_ocpsandbox_gitea_user`.
+
+### Key Behaviors
+
+- Admin creds auto-discovered from the Gitea CR if not provided
+- User creation is idempotent: 201 = new, 422 = already exists (updates password)
+- Repo migration is idempotent: 201 = migrated, 409 = already exists
+- Destroy uses `?purge=true` to delete the user and all their data
+
+### Destroy
+
+Removes: Gitea user and all their repositories (purge).
+
+## Prerequisites
+
+- Gitea deployed via `ocp4_workload_gitea_operator` (cluster provisioning)
+- `ocp4_workload_ocpsandbox_keycloak_user` must run first (for cluster connectivity)

--- a/roles/ocp4_workload_ocpsandbox_gitea_user/defaults/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_user/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cluster connection (from sandbox)
 ocp4_workload_ocpsandbox_gitea_user_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-ocp4_workload_ocpsandbox_gitea_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token }}"
+ocp4_workload_ocpsandbox_gitea_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
 
 # User to create -- defaults to userX-GUID format
 ocp4_workload_ocpsandbox_gitea_user_username: "user1-{{ guid }}"

--- a/roles/ocp4_workload_ocpsandbox_gitea_user/defaults/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_user/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# Cluster connection (from sandbox)
+ocp4_workload_ocpsandbox_gitea_user_openshift_api_url: "{{ sandbox_openshift_api_url }}"
+ocp4_workload_ocpsandbox_gitea_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token }}"
+
+# User to create -- defaults to userX-GUID format
+ocp4_workload_ocpsandbox_gitea_user_username: "user1-{{ guid }}"
+ocp4_workload_ocpsandbox_gitea_user_password: ""
+
+# Gitea configuration
+ocp4_workload_ocpsandbox_gitea_user_namespace: gitea
+ocp4_workload_ocpsandbox_gitea_user_admin_user: ""
+ocp4_workload_ocpsandbox_gitea_user_admin_password: ""
+
+# Repositories to migrate for the user
+ocp4_workload_ocpsandbox_gitea_user_repositories: []
+# Example:
+# - name: mcp
+#   repo: https://github.com/rhpds/mcp-gitops
+#   private: false

--- a/roles/ocp4_workload_ocpsandbox_gitea_user/meta/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_user/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_ocpsandbox_gitea_user
+  author: Red Hat, Prakhar Srivastava
+  description: |
+    Dynamic Gitea user provisioning on shared OCP clusters.
+    Creates Gitea user via REST API and migrates repositories.
+    Designed for namespace config with sandbox API pattern.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - gitea
+dependencies: []

--- a/roles/ocp4_workload_ocpsandbox_gitea_user/tasks/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_user/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks: remove_workload.yml

--- a/roles/ocp4_workload_ocpsandbox_gitea_user/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_user/tasks/remove_workload.yml
@@ -1,0 +1,49 @@
+---
+# Thorough Gitea cleanup for long-running shared clusters.
+
+- name: Discover Gitea admin credentials from CR
+  when: ocp4_workload_ocpsandbox_gitea_user_admin_user | default('') | length == 0
+  block:
+  - name: Get Gitea CR
+    kubernetes.core.k8s_info:
+      host: "{{ ocp4_workload_ocpsandbox_gitea_user_openshift_api_url }}"
+      api_key: "{{ ocp4_workload_ocpsandbox_gitea_user_openshift_api_token }}"
+      validate_certs: false
+      api_version: pfe.rhpds.com/v1
+      kind: Gitea
+      namespace: "{{ ocp4_workload_ocpsandbox_gitea_user_namespace }}"
+    register: r_gitea_cr
+
+  - name: Set Gitea admin credentials from CR
+    ansible.builtin.set_fact:
+      ocp4_workload_ocpsandbox_gitea_user_admin_user: >-
+        {{ r_gitea_cr.resources[0].spec.giteaAdminUser }}
+      ocp4_workload_ocpsandbox_gitea_user_admin_password: >-
+        {{ r_gitea_cr.resources[0].spec.giteaAdminPassword }}
+
+- name: Discover Gitea URL from route
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_gitea_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_gitea_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: "{{ ocp4_workload_ocpsandbox_gitea_user_namespace }}"
+    label_selectors:
+    - app=gitea
+  register: r_gitea_route
+
+- name: Set Gitea URL fact
+  ansible.builtin.set_fact:
+    _ocp4_workload_ocpsandbox_gitea_user_url: >-
+      https://{{ r_gitea_route.resources[0].spec.host }}
+
+- name: Delete Gitea user and all their repos
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_gitea_user_url }}/api/v1/admin/users/{{ ocp4_workload_ocpsandbox_gitea_user_username }}?purge=true"
+    method: DELETE
+    validate_certs: false
+    url_username: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_user }}"
+    url_password: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_password }}"
+    force_basic_auth: true
+    status_code: [204, 404]

--- a/roles/ocp4_workload_ocpsandbox_gitea_user/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_gitea_user/tasks/workload.yml
@@ -1,0 +1,113 @@
+---
+- name: Discover Gitea admin credentials from CR
+  when: ocp4_workload_ocpsandbox_gitea_user_admin_user | default('') | length == 0
+  block:
+  - name: Get Gitea CR
+    kubernetes.core.k8s_info:
+      host: "{{ ocp4_workload_ocpsandbox_gitea_user_openshift_api_url }}"
+      api_key: "{{ ocp4_workload_ocpsandbox_gitea_user_openshift_api_token }}"
+      validate_certs: false
+      api_version: pfe.rhpds.com/v1
+      kind: Gitea
+      namespace: "{{ ocp4_workload_ocpsandbox_gitea_user_namespace }}"
+    register: r_gitea_cr
+
+  - name: Set Gitea admin credentials from CR
+    ansible.builtin.set_fact:
+      ocp4_workload_ocpsandbox_gitea_user_admin_user: >-
+        {{ r_gitea_cr.resources[0].spec.giteaAdminUser }}
+      ocp4_workload_ocpsandbox_gitea_user_admin_password: >-
+        {{ r_gitea_cr.resources[0].spec.giteaAdminPassword }}
+
+- name: Discover Gitea URL from route
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_gitea_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_gitea_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: "{{ ocp4_workload_ocpsandbox_gitea_user_namespace }}"
+    label_selectors:
+    - app=gitea
+  register: r_gitea_route
+
+- name: Set Gitea URL fact
+  ansible.builtin.set_fact:
+    _ocp4_workload_ocpsandbox_gitea_user_url: >-
+      https://{{ r_gitea_route.resources[0].spec.host }}
+
+- name: Create Gitea user
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_gitea_user_url }}/api/v1/admin/users"
+    method: POST
+    validate_certs: false
+    body_format: json
+    url_username: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_user }}"
+    url_password: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_password }}"
+    force_basic_auth: true
+    body:
+      username: "{{ ocp4_workload_ocpsandbox_gitea_user_username }}"
+      password: "{{ ocp4_workload_ocpsandbox_gitea_user_password }}"
+      email: "{{ ocp4_workload_ocpsandbox_gitea_user_username }}@demo.redhat.com"
+      must_change_password: false
+    status_code: [201, 422]
+  register: r_gitea_create_user
+
+- name: Handle existing user
+  when: r_gitea_create_user.status == 422
+  block:
+  - name: Get Gitea user ID for existing user
+    ansible.builtin.uri:
+      url: "{{ _ocp4_workload_ocpsandbox_gitea_user_url }}/api/v1/users/{{ ocp4_workload_ocpsandbox_gitea_user_username }}"
+      method: GET
+      validate_certs: false
+      url_username: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_user }}"
+      url_password: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_password }}"
+      force_basic_auth: true
+    register: r_gitea_existing_user
+
+  - name: Update existing user password via admin API
+    ansible.builtin.uri:
+      url: >-
+        {{ _ocp4_workload_ocpsandbox_gitea_user_url }}/api/v1/admin/users/{{ ocp4_workload_ocpsandbox_gitea_user_username }}
+      method: PATCH
+      validate_certs: false
+      body_format: json
+      url_username: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_user }}"
+      url_password: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_password }}"
+      force_basic_auth: true
+      body:
+        login_name: "{{ ocp4_workload_ocpsandbox_gitea_user_username }}"
+        source_id: 0
+        password: "{{ ocp4_workload_ocpsandbox_gitea_user_password }}"
+        must_change_password: false
+      status_code: 200
+
+- name: Migrate repositories for user
+  when: ocp4_workload_ocpsandbox_gitea_user_repositories | length > 0
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_gitea_user_url }}/api/v1/repos/migrate"
+    method: POST
+    validate_certs: false
+    body_format: json
+    url_username: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_user }}"
+    url_password: "{{ ocp4_workload_ocpsandbox_gitea_user_admin_password }}"
+    force_basic_auth: true
+    body:
+      clone_addr: "{{ repo_item.repo }}"
+      repo_name: "{{ repo_item.name }}"
+      repo_owner: "{{ ocp4_workload_ocpsandbox_gitea_user_username }}"
+      mirror: false
+      private: "{{ repo_item.private | default(false) }}"
+    status_code: [201, 409]
+  loop: "{{ ocp4_workload_ocpsandbox_gitea_user_repositories }}"
+  loop_control:
+    loop_var: repo_item
+    label: "{{ repo_item.name }}"
+
+- name: Save Gitea user information
+  agnosticd.core.agnosticd_user_info:
+    data:
+      gitea_url: "{{ _ocp4_workload_ocpsandbox_gitea_user_url }}"
+      gitea_user: "{{ ocp4_workload_ocpsandbox_gitea_user_username }}"
+      gitea_password: "{{ ocp4_workload_ocpsandbox_gitea_user_password }}"

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/README.md
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/README.md
@@ -4,7 +4,9 @@ User provisioning role for OcpSandbox clusters with Keycloak (RHBK) authenticati
 
 ## When to Use
 
-Use this role as the **first workload** in any OcpSandbox (`config: namespace`) catalog item where the cluster uses Keycloak for authentication. It handles kubeconfig setup, cluster discovery, and user creation -- things that `config: namespace` does NOT do automatically.
+Use this role as the **first workload** in any OcpSandbox (`config: namespace`) catalog item where the cluster uses Red Hat build of Keycloak (RHBK) for authentication. It handles kubeconfig setup, cluster discovery, and user creation -- things that `config: namespace` does NOT do automatically.
+
+This role is specifically for clusters where RHBK is the OAuth identity provider (deployed via `ocp4_workload_authentication_keycloak`). If the cluster uses htpasswd or another auth method, this role is not applicable.
 
 ## Why It Exists
 

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/README.md
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/README.md
@@ -1,0 +1,73 @@
+# ocp4_workload_ocpsandbox_keycloak_user
+
+User provisioning role for OcpSandbox clusters with Keycloak (RHBK) authentication.
+
+## When to Use
+
+Use this role as the **first workload** in any OcpSandbox (`config: namespace`) catalog item where the cluster uses Keycloak for authentication. It handles kubeconfig setup, cluster discovery, and user creation -- things that `config: namespace` does NOT do automatically.
+
+## Why It Exists
+
+The `config: namespace` pattern in AgnosticD v2 runs workloads on `localhost` with no automatic cluster auth setup or discovery. This role fills that gap for sandbox deployments by:
+
+1. Writing a kubeconfig from the sandbox-provided SA token
+2. Discovering cluster info (ingress domain, console URL, API URL)
+3. Creating a Keycloak user via REST API so the student can log in
+
+Without this role, downstream workloads would have no cluster connection and no way to discover ingress domains or console URLs.
+
+## How to Use
+
+### In AgV catalog (`common.yaml`)
+
+```yaml
+config: namespace
+
+# Provision order -- keycloak_user must be first
+workloads:
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_keycloak_user
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_gitea_user
+# ... other workloads
+
+# Destroy order -- keycloak_user must be last (cleans up cluster connection)
+remove_workloads:
+# ... other workloads in reverse
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_gitea_user
+- agnosticd.namespaced_workloads.ocp4_workload_ocpsandbox_keycloak_user
+
+# Variables
+ocp4_workload_ocpsandbox_keycloak_user_username: "user1-{{ guid }}"
+ocp4_workload_ocpsandbox_keycloak_user_password: "{{ common_password }}"
+ocp4_workload_ocpsandbox_keycloak_user_keycloak_realm: sso
+```
+
+The role uses `ACTION` variable (set automatically by AgnosticD): `provision` runs `workload.yml`, `destroy` runs `remove_workload.yml`.
+
+### Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `_openshift_api_url` | `{{ sandbox_openshift_api_url }}` | Cluster API URL (from sandbox) |
+| `_openshift_api_token` | `{{ cluster_admin_agnosticd_sa_token }}` | SA token (from sandbox) |
+| `_username` | `user1-{{ guid }}` | Username to create |
+| `_password` | (required) | Password for the user |
+| `_keycloak_namespace` | `keycloak` | Namespace where RHBK is deployed |
+| `_keycloak_realm` | `openshift` | Keycloak realm for user creation |
+| `_keycloak_admin_secret` | `keycloak-initial-admin` | K8s secret with admin creds |
+
+All variables are prefixed with `ocp4_workload_ocpsandbox_keycloak_user`.
+
+### Facts Set for Downstream Roles
+
+- `openshift_cluster_ingress_domain` -- e.g. `apps.cluster-x2r6h.dynamic.redhatworkshops.io`
+- `openshift_console_url` -- e.g. `https://console-openshift-console.apps...`
+- `openshift_api_url` -- e.g. `https://api.cluster-x2r6h.dynamic.redhatworkshops.io:6443`
+
+### Destroy
+
+Removes: Keycloak user, OCP Identity, OCP User object, per-user namespaces, ClusterRoleBindings.
+
+## Prerequisites
+
+- Cluster must have RHBK (Keycloak) deployed via `ocp4_workload_authentication_keycloak`
+- `cluster_admin_agnosticd_sa_token` and `sandbox_openshift_api_url` provided by sandbox

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/defaults/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cluster connection (from sandbox)
 ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token }}"
+ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
 
 # User to create -- defaults to userX-GUID format
 ocp4_workload_ocpsandbox_keycloak_user_username: "user1-{{ guid }}"

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/defaults/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# Cluster connection (from sandbox)
+ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url: "{{ sandbox_openshift_api_url }}"
+ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token }}"
+
+# User to create -- defaults to userX-GUID format
+ocp4_workload_ocpsandbox_keycloak_user_username: "user1-{{ guid }}"
+ocp4_workload_ocpsandbox_keycloak_user_password: ""
+
+# Keycloak configuration
+ocp4_workload_ocpsandbox_keycloak_user_keycloak_namespace: keycloak
+ocp4_workload_ocpsandbox_keycloak_user_keycloak_realm: openshift
+ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_secret: keycloak-initial-admin

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/meta/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_ocpsandbox_keycloak_user
+  author: Red Hat, Prakhar Srivastava
+  description: |
+    Dynamic Keycloak user provisioning on shared OCP clusters.
+    Sets up kubeconfig, discovers cluster info, creates Keycloak user via REST API.
+    Designed for namespace config with sandbox API pattern.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - keycloak
+dependencies: []

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/create_keycloak_user.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/create_keycloak_user.yml
@@ -1,0 +1,74 @@
+---
+- name: Get Keycloak admin credentials from secret
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: v1
+    kind: Secret
+    name: "{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_secret }}"
+    namespace: "{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_namespace }}"
+  register: r_keycloak_admin_secret
+
+- name: Set Keycloak admin credentials
+  ansible.builtin.set_fact:
+    _ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_user: >-
+      {{ r_keycloak_admin_secret.resources[0].data.username | b64decode }}
+    _ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_password: >-
+      {{ r_keycloak_admin_secret.resources[0].data.password | b64decode }}
+    _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host: >-
+      https://sso.{{ _ocp4_workload_ocpsandbox_keycloak_user_ingress_domain }}
+
+- name: Get Keycloak admin access token
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host }}/realms/master/protocol/openid-connect/token"
+    method: POST
+    validate_certs: false
+    body_format: form-urlencoded
+    body:
+      client_id: admin-cli
+      username: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_user }}"
+      password: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_password }}"
+      grant_type: password
+  register: r_keycloak_token
+
+- name: Create user in Keycloak
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host }}/admin/realms/{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_realm }}/users"
+    method: POST
+    validate_certs: false
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ r_keycloak_token.json.access_token }}"
+    body:
+      username: "{{ ocp4_workload_ocpsandbox_keycloak_user_username }}"
+      enabled: true
+      firstName: "{{ ocp4_workload_ocpsandbox_keycloak_user_username }}"
+      lastName: Demo
+      email: "{{ ocp4_workload_ocpsandbox_keycloak_user_username }}@demo.redhat.com"
+      emailVerified: true
+    status_code: [201, 409]
+  register: r_keycloak_create_user
+
+- name: Get user ID from Keycloak
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host }}/admin/realms/{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_realm }}/users?username={{ ocp4_workload_ocpsandbox_keycloak_user_username }}"
+    method: GET
+    validate_certs: false
+    headers:
+      Authorization: "Bearer {{ r_keycloak_token.json.access_token }}"
+  register: r_keycloak_user
+
+- name: Set password for Keycloak user
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host }}/admin/realms/{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_realm }}/users/{{ r_keycloak_user.json[0].id }}/reset-password"
+    method: PUT
+    validate_certs: false
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ r_keycloak_token.json.access_token }}"
+    body:
+      type: password
+      temporary: false
+      value: "{{ ocp4_workload_ocpsandbox_keycloak_user_password }}"
+    status_code: 204

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/main.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks: remove_workload.yml

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/remove_workload.yml
@@ -1,0 +1,152 @@
+---
+# Thorough cleanup for long-running shared clusters.
+
+- name: Set up cluster access for destroy
+  ansible.builtin.include_tasks: setup_kubeconfig.yml
+
+# -----------------------------------------------
+# Keycloak user cleanup
+# -----------------------------------------------
+- name: Get Keycloak admin credentials from secret
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: v1
+    kind: Secret
+    name: "{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_secret }}"
+    namespace: "{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_namespace }}"
+  register: r_keycloak_admin_secret
+
+- name: Set Keycloak admin credentials
+  ansible.builtin.set_fact:
+    _ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_user: >-
+      {{ r_keycloak_admin_secret.resources[0].data.username | b64decode }}
+    _ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_password: >-
+      {{ r_keycloak_admin_secret.resources[0].data.password | b64decode }}
+    _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host: >-
+      https://sso.{{ _ocp4_workload_ocpsandbox_keycloak_user_ingress_domain }}
+
+- name: Get Keycloak admin access token
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host }}/realms/master/protocol/openid-connect/token"
+    method: POST
+    validate_certs: false
+    body_format: form-urlencoded
+    body:
+      client_id: admin-cli
+      username: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_user }}"
+      password: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_admin_password }}"
+      grant_type: password
+  register: r_keycloak_token
+
+- name: Get user ID from Keycloak
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host }}/admin/realms/{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_realm }}/users?username={{ ocp4_workload_ocpsandbox_keycloak_user_username }}&exact=true"
+    method: GET
+    validate_certs: false
+    headers:
+      Authorization: "Bearer {{ r_keycloak_token.json.access_token }}"
+  register: r_keycloak_user
+
+- name: Delete user from Keycloak
+  when: r_keycloak_user.json | length > 0
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_keycloak_host }}/admin/realms/{{ ocp4_workload_ocpsandbox_keycloak_user_keycloak_realm }}/users/{{ r_keycloak_user.json[0].id }}"
+    method: DELETE
+    validate_certs: false
+    headers:
+      Authorization: "Bearer {{ r_keycloak_token.json.access_token }}"
+    status_code: 204
+
+# -----------------------------------------------
+# OCP Identity and User cleanup
+# -----------------------------------------------
+- name: Delete OCP Identity for Keycloak user
+  when: r_keycloak_user.json | length > 0
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    state: absent
+    api_version: user.openshift.io/v1
+    kind: Identity
+    name: "rhbk:{{ r_keycloak_user.json[0].id }}"
+  ignore_errors: true
+
+- name: Delete OCP User object
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    state: absent
+    api_version: user.openshift.io/v1
+    kind: User
+    name: "{{ ocp4_workload_ocpsandbox_keycloak_user_username }}"
+  ignore_errors: true
+
+# -----------------------------------------------
+# Delete all namespaces owned by this user
+# -----------------------------------------------
+- name: Get all namespaces matching user pattern
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: v1
+    kind: Namespace
+  register: r_all_namespaces
+
+- name: Delete namespaces ending with user identifier
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    state: absent
+    api_version: v1
+    kind: Namespace
+    name: "{{ ns_item.metadata.name }}"
+  loop: >-
+    {{ r_all_namespaces.resources
+       | selectattr('metadata.name', 'match', '.*-' ~ ocp4_workload_ocpsandbox_keycloak_user_username ~ '$')
+       | list }}
+  loop_control:
+    loop_var: ns_item
+    label: "{{ ns_item.metadata.name }}"
+  ignore_errors: true
+
+# -----------------------------------------------
+# Cleanup cluster-scoped resources for user
+# -----------------------------------------------
+- name: Get ClusterRoleBindings
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+  register: r_crbs
+
+- name: Remove ClusterRoleBindings referencing user
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    name: "{{ crb_item.metadata.name }}"
+  loop: >-
+    {{ r_crbs.resources
+       | selectattr('subjects', 'defined')
+       | selectattr('metadata.name', 'search', ocp4_workload_ocpsandbox_keycloak_user_username)
+       | list }}
+  loop_control:
+    loop_var: crb_item
+    label: "{{ crb_item.metadata.name }}"
+  ignore_errors: true
+
+- name: Remove kubeconfig
+  ansible.builtin.file:
+    path: "{{ lookup('env', 'HOME') }}/.kube/config"
+    state: absent

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/remove_workload.yml
@@ -148,5 +148,5 @@
 
 - name: Remove kubeconfig
   ansible.builtin.file:
-    path: "{{ lookup('env', 'HOME') }}/.kube/config"
+    path: "{{ lookup('env', 'KUBECONFIG') | default(lookup('env', 'HOME') ~ '/.kube/config', true) }}"
     state: absent

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/setup_kubeconfig.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/setup_kubeconfig.yml
@@ -1,0 +1,55 @@
+---
+- name: Discover cluster ingress domain
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: r_ingress_config
+
+- name: Set ingress domain fact
+  ansible.builtin.set_fact:
+    _ocp4_workload_ocpsandbox_keycloak_user_ingress_domain: >-
+      {{ r_ingress_config.resources[0].spec.domain }}
+
+- name: Discover cluster console URL
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}"
+    validate_certs: false
+    api_version: config.openshift.io/v1
+    kind: Console
+    name: cluster
+  register: r_console_config
+
+- name: Set console URL fact
+  ansible.builtin.set_fact:
+    _ocp4_workload_ocpsandbox_keycloak_user_console_url: >-
+      {{ r_console_config.resources[0].status.consoleURL }}
+
+- name: Set cluster info facts for downstream roles
+  ansible.builtin.set_fact:
+    openshift_cluster_ingress_domain: "{{ _ocp4_workload_ocpsandbox_keycloak_user_ingress_domain }}"
+    openshift_console_url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_console_url }}"
+    openshift_api_url: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+
+- name: Create kubeconfig directory
+  ansible.builtin.file:
+    path: "{{ lookup('env', 'HOME') }}/.kube"
+    state: directory
+    mode: "0700"
+
+- name: Write kubeconfig for downstream roles
+  ansible.builtin.template:
+    src: kubeconfig.j2
+    dest: "{{ lookup('env', 'HOME') }}/.kube/config"
+    mode: "0600"
+
+- name: Display cluster info
+  ansible.builtin.debug:
+    msg: >-
+      Cluster: {{ openshift_api_url }}
+      Ingress domain: {{ openshift_cluster_ingress_domain }}
+      Console: {{ openshift_console_url }}

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/setup_kubeconfig.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/setup_kubeconfig.yml
@@ -35,16 +35,23 @@
     openshift_console_url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_console_url }}"
     openshift_api_url: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
 
+- name: Set kubeconfig path
+  ansible.builtin.set_fact:
+    _kubeconfig_path: "{{ lookup('env', 'KUBECONFIG') | default(lookup('env', 'HOME') ~ '/.kube/config', true) }}"
+
 - name: Create kubeconfig directory
   ansible.builtin.file:
-    path: "{{ lookup('env', 'HOME') }}/.kube"
+    path: "{{ _kubeconfig_path | dirname }}"
     state: directory
     mode: "0700"
+  when:
+  - _kubeconfig_path | dirname != '/tmp'
+  - _kubeconfig_path | dirname != '/private/tmp'
 
 - name: Write kubeconfig for downstream roles
   ansible.builtin.template:
     src: kubeconfig.j2
-    dest: "{{ lookup('env', 'HOME') }}/.kube/config"
+    dest: "{{ _kubeconfig_path }}"
     mode: "0600"
 
 - name: Display cluster info

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/workload.yml
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/tasks/workload.yml
@@ -1,0 +1,15 @@
+---
+- name: Set up cluster access and discover cluster info
+  ansible.builtin.include_tasks: setup_kubeconfig.yml
+
+- name: Create Keycloak user
+  ansible.builtin.include_tasks: create_keycloak_user.yml
+
+- name: Save user information
+  agnosticd.core.agnosticd_user_info:
+    data:
+      user: "{{ ocp4_workload_ocpsandbox_keycloak_user_username }}"
+      password: "{{ ocp4_workload_ocpsandbox_keycloak_user_password }}"
+      openshift_api_url: "{{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}"
+      openshift_console_url: "{{ _ocp4_workload_ocpsandbox_keycloak_user_console_url }}"
+      openshift_cluster_ingress_domain: "{{ _ocp4_workload_ocpsandbox_keycloak_user_ingress_domain }}"

--- a/roles/ocp4_workload_ocpsandbox_keycloak_user/templates/kubeconfig.j2
+++ b/roles/ocp4_workload_ocpsandbox_keycloak_user/templates/kubeconfig.j2
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: {{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_url }}
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    user: admin
+  name: default
+current-context: default
+users:
+- name: admin
+  user:
+    token: {{ ocp4_workload_ocpsandbox_keycloak_user_openshift_api_token }}


### PR DESCRIPTION
## Summary
- Add three reusable sandbox roles for user provisioning on shared OCP clusters:
  - `ocp4_workload_ocpsandbox_keycloak_user` — kubeconfig setup, cluster discovery, Keycloak user creation
  - `ocp4_workload_ocpsandbox_gitea_user` — Gitea user creation, repository migration
  - `ocp4_workload_ocpsandbox_argocd_user` — ArgoCD AppProject with user RBAC
- Trim vault-decrypted admin tokens to prevent invalid HTTP header errors from trailing newlines
- Support KUBECONFIG env var in keycloak_user role

## Test plan
- [ ] Verified provision + destroy on cnv-us-east-ocp-3 (ok=113 changed=13 failed=0 / ok=74 changed=7 failed=0)
- [ ] Verified on test clusters zfmv7, n9hm5, xtfpx