### PR TITLE
feat: add tenant OpenShift GitOps role for user-scoped ArgoCD access

### DIFF
--- a/roles/ocp4_workload_tenant_openshift_gitops/README.md
+++ b/roles/ocp4_workload_tenant_openshift_gitops/README.md
@@ -1,0 +1,145 @@
+# ocp4_workload_tenant_openshift_gitops
+
+Ansible role to configure tenant-scoped access to an existing OpenShift GitOps (ArgoCD) instance. This role creates an ArgoCD AppProject for a single user and configures authentication and RBAC without requiring multi-user provisioning logic.
+
+## Requirements
+
+- OpenShift GitOps operator already installed and running in `openshift-gitops` namespace
+- Cluster admin API credentials for the target cluster
+- Python passlib library (for bcrypt password hashing)
+
+## Role Variables
+
+### Required Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ocp4_workload_tenant_openshift_gitops_openshift_api_url` | OpenShift API URL | `{{ sandbox_openshift_api_url }}` |
+| `ocp4_workload_tenant_openshift_gitops_openshift_api_token` | Cluster admin API token | `{{ cluster_admin_agnosticd_sa_token \| trim }}` |
+| `ocp4_workload_tenant_openshift_gitops_user` | Username for ArgoCD access | `user-{{ guid }}` |
+| `ocp4_workload_tenant_openshift_gitops_user_password` | Password for ArgoCD login | `{{ common_password \| default('openshift') }}` |
+
+### Optional Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ocp4_workload_tenant_openshift_gitops_user_project_prefix` | Prefix for AppProject name | `appproject-` |
+| `ocp4_workload_tenant_openshift_gitops_user_cluster_resource_whitelist` | Cluster-scoped resources allowed in AppProject | `[{ group: "", kind: Namespace }]` |
+
+## AppProject Naming
+
+The AppProject name is constructed as: `{{ prefix }}-{{ user }}`
+
+Example: With default prefix `appproject-` and user `user-abc123`, the AppProject name will be `appproject-user-abc123`
+
+## Namespace Access Pattern
+
+Users can deploy applications to namespaces matching the pattern: `{{ username }}-*`
+
+Example: User `user-abc123` can deploy to:
+- `user-abc123-dev`
+- `user-abc123-prod`
+- `user-abc123-gitops`
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+```yaml
+---
+- name: Configure tenant GitOps access
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: Setup ArgoCD tenant access
+    ansible.builtin.include_role:
+      name: ocp4_workload_tenant_openshift_gitops
+    vars:
+      ocp4_workload_tenant_openshift_gitops_user: "user-demo"
+      ocp4_workload_tenant_openshift_gitops_user_cluster_resource_whitelist:
+      - group: ""
+        kind: Namespace
+      - group: rbac.authorization.k8s.io
+        kind: ClusterRole
+```
+
+## Example with Custom Configuration
+
+```yaml
+---
+- name: Configure tenant GitOps with custom settings
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: Setup ArgoCD tenant access
+    ansible.builtin.include_role:
+      name: ocp4_workload_tenant_openshift_gitops
+    vars:
+      ocp4_workload_tenant_openshift_gitops_openshift_api_url: "https://api.cluster.example.com:6443"
+      ocp4_workload_tenant_openshift_gitops_openshift_api_token: "sha256~abc123..."
+      ocp4_workload_tenant_openshift_gitops_user: "developer1"
+      ocp4_workload_tenant_openshift_gitops_user_project_prefix: "tenant-"
+```
+
+## What This Role Does
+
+### Provision (`ACTION=provision`)
+
+1. **Creates AppProject** - Creates a tenant-scoped ArgoCD AppProject
+2. **Registers User Account** - Adds user account to ArgoCD configuration (`argocd-cm`)
+3. **Sets Password** - Generates bcrypt hash and stores in ArgoCD secret (`argocd-secret`)
+4. **Configures RBAC** - Maps user to AppProject role in ArgoCD RBAC (`argocd-rbac-cm`)
+5. **Outputs User Data** - Provides ArgoCD URL, username, password, and AppProject name
+
+### Destroy (`ACTION=destroy`)
+
+1. **Removes AppProject** - Deletes the tenant's AppProject
+2. **Removes User Account** - Cleans up user account from `argocd-cm`
+3. **Removes Password** - Cleans up password from `argocd-secret`
+
+## User Access
+
+After provisioning, users can log in to ArgoCD:
+
+- **URL**: Retrieved from the `openshift-gitops-server` route
+- **Username**: Value of `ocp4_workload_tenant_openshift_gitops_user`
+- **Password**: Value of `ocp4_workload_tenant_openshift_gitops_user_password`
+
+## Output Variables
+
+The role outputs the following data via `agnosticd_user_info`:
+
+```yaml
+openshift_gitops_server: "https://openshift-gitops-server-openshift-gitops.apps.cluster.example.com"
+openshift_gitops_user: "user-abc123"
+openshift_gitops_password: "openshift"
+openshift_gitops_appproject: "appproject-user-abc123"
+```
+
+## Cluster Resource Whitelist
+
+Control which cluster-scoped resources users can manage in their AppProject:
+
+```yaml
+ocp4_workload_tenant_openshift_gitops_user_cluster_resource_whitelist:
+- group: ""
+  kind: Namespace
+- group: rbac.authorization.k8s.io
+  kind: ClusterRole
+- group: rbac.authorization.k8s.io
+  kind: ClusterRoleBinding
+```
+
+## RBAC Behavior
+
+The role **appends** to existing RBAC policy in `argocd-rbac-cm` using `state: patched`. This preserves other users' RBAC configurations.
+
+## License
+
+GPL-3.0-or-later
+
+## Author Information
+
+Red Hat GPTE

--- a/roles/ocp4_workload_tenant_openshift_gitops/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# Cluster connection
+ocp4_workload_tenant_openshift_gitops_openshift_api_url: "{{ sandbox_openshift_api_url }}"
+ocp4_workload_tenant_openshift_gitops_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
+
+# User to create AppProject for
+ocp4_workload_tenant_openshift_gitops_user: "user-{{ guid }}"
+
+# User credentials for ArgoCD login
+ocp4_workload_tenant_openshift_gitops_user_password: "{{ common_password | default('openshift') }}"
+
+# Prefix for AppProject name
+ocp4_workload_tenant_openshift_gitops_user_project_prefix: "appproject"
+
+# Cluster-scoped resources allowed in the AppProject
+# Example: [{ group: "", kind: Namespace }]
+ocp4_workload_tenant_openshift_gitops_user_cluster_resource_whitelist:
+- group: ""
+  kind: Namespace

--- a/roles/ocp4_workload_tenant_openshift_gitops/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/defaults/main.yml
@@ -3,6 +3,9 @@
 ocp4_workload_tenant_openshift_gitops_openshift_api_url: "{{ sandbox_openshift_api_url }}"
 ocp4_workload_tenant_openshift_gitops_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
 
+# OpenShift GitOps namespace
+ocp4_workload_tenant_openshift_gitops_namespace: openshift-gitops
+
 # User to create AppProject for
 ocp4_workload_tenant_openshift_gitops_user: "user-{{ guid }}"
 

--- a/roles/ocp4_workload_tenant_openshift_gitops/meta/main.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: Red Hat GPTE
+  description: Tenant-specific OpenShift GitOps (ArgoCD) configuration
+  company: Red Hat
+  license: GPL-3.0-or-later
+  min_ansible_version: '2.15'
+  platforms:
+  - name: Fedora
+    versions:
+    - all
+
+dependencies: []

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/main.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks:
+    file: remove_workload.yml

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
@@ -12,14 +12,14 @@
       api_version: argoproj.io/v1alpha1
       kind: AppProject
       name: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
 
   - name: Get current argocd-cm ConfigMap
     kubernetes.core.k8s_info:
       api_version: v1
       kind: ConfigMap
       name: argocd-cm
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
     register: r_argocd_cm
 
   - name: Remove user account from argocd-cm
@@ -32,7 +32,7 @@
       api_version: v1
       kind: ConfigMap
       name: argocd-cm
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       definition:
         data: "{{ r_argocd_cm.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) | items2dict }}"
 
@@ -41,7 +41,7 @@
       api_version: v1
       kind: Secret
       name: argocd-secret
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
     register: r_argocd_secret
 
   - name: Remove user password from argocd-secret
@@ -54,6 +54,6 @@
       api_version: v1
       kind: Secret
       name: argocd-secret
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       definition:
         data: "{{ r_argocd_secret.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') | items2dict }}"

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
@@ -1,0 +1,52 @@
+---
+- name: Remove tenant AppProject
+  kubernetes.core.k8s:
+    state: absent
+    api_version: argoproj.io/v1alpha1
+    kind: AppProject
+    name: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}{{ ocp4_workload_tenant_openshift_gitops_user }}"
+    namespace: openshift-gitops
+
+- name: Get current argocd-cm ConfigMap
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: argocd-cm
+    namespace: openshift-gitops
+  register: r_argocd_cm
+
+- name: Remove user account from argocd-cm
+  when:
+  - r_argocd_cm.resources | length > 0
+  - r_argocd_cm.resources[0].data is defined
+  - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) in r_argocd_cm.resources[0].data
+  kubernetes.core.k8s:
+    state: present
+    api_version: v1
+    kind: ConfigMap
+    name: argocd-cm
+    namespace: openshift-gitops
+    definition:
+      data: "{{ r_argocd_cm.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) | items2dict }}"
+
+- name: Get current argocd-secret Secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: argocd-secret
+    namespace: openshift-gitops
+  register: r_argocd_secret
+
+- name: Remove user password from argocd-secret
+  when:
+  - r_argocd_secret.resources | length > 0
+  - r_argocd_secret.resources[0].data is defined
+  - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') in r_argocd_secret.resources[0].data
+  kubernetes.core.k8s:
+    state: present
+    api_version: v1
+    kind: Secret
+    name: argocd-secret
+    namespace: openshift-gitops
+    definition:
+      data: "{{ r_argocd_secret.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') | items2dict }}"

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
@@ -1,6 +1,9 @@
 ---
 - name: Remove tenant AppProject
   kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     state: absent
     api_version: argoproj.io/v1alpha1
     kind: AppProject
@@ -9,6 +12,9 @@
 
 - name: Get current argocd-cm ConfigMap
   kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     api_version: v1
     kind: ConfigMap
     name: argocd-cm
@@ -21,6 +27,9 @@
   - r_argocd_cm.resources[0].data is defined
   - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) in r_argocd_cm.resources[0].data
   kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     state: present
     api_version: v1
     kind: ConfigMap
@@ -31,6 +40,9 @@
 
 - name: Get current argocd-secret Secret
   kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     api_version: v1
     kind: Secret
     name: argocd-secret
@@ -43,6 +55,9 @@
   - r_argocd_secret.resources[0].data is defined
   - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') in r_argocd_secret.resources[0].data
   kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     state: present
     api_version: v1
     kind: Secret

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
@@ -1,67 +1,59 @@
 ---
-- name: Remove tenant AppProject
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    state: absent
-    api_version: argoproj.io/v1alpha1
-    kind: AppProject
-    name: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
-    namespace: openshift-gitops
+- name: Remove tenant OpenShift GitOps access
+  module_defaults:
+    group/kubernetes.core.k8s:
+      host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+      api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+      validate_certs: false
+  block:
+  - name: Remove tenant AppProject
+    kubernetes.core.k8s:
+      state: absent
+      api_version: argoproj.io/v1alpha1
+      kind: AppProject
+      name: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
+      namespace: openshift-gitops
 
-- name: Get current argocd-cm ConfigMap
-  kubernetes.core.k8s_info:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    api_version: v1
-    kind: ConfigMap
-    name: argocd-cm
-    namespace: openshift-gitops
-  register: r_argocd_cm
+  - name: Get current argocd-cm ConfigMap
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: ConfigMap
+      name: argocd-cm
+      namespace: openshift-gitops
+    register: r_argocd_cm
 
-- name: Remove user account from argocd-cm
-  when:
-  - r_argocd_cm.resources | length > 0
-  - r_argocd_cm.resources[0].data is defined
-  - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) in r_argocd_cm.resources[0].data
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    api_version: v1
-    kind: ConfigMap
-    name: argocd-cm
-    namespace: openshift-gitops
-    definition:
-      data: "{{ r_argocd_cm.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) | items2dict }}"
+  - name: Remove user account from argocd-cm
+    when:
+    - r_argocd_cm.resources | length > 0
+    - r_argocd_cm.resources[0].data is defined
+    - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) in r_argocd_cm.resources[0].data
+    kubernetes.core.k8s:
+      state: present
+      api_version: v1
+      kind: ConfigMap
+      name: argocd-cm
+      namespace: openshift-gitops
+      definition:
+        data: "{{ r_argocd_cm.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) | items2dict }}"
 
-- name: Get current argocd-secret Secret
-  kubernetes.core.k8s_info:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    api_version: v1
-    kind: Secret
-    name: argocd-secret
-    namespace: openshift-gitops
-  register: r_argocd_secret
+  - name: Get current argocd-secret Secret
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Secret
+      name: argocd-secret
+      namespace: openshift-gitops
+    register: r_argocd_secret
 
-- name: Remove user password from argocd-secret
-  when:
-  - r_argocd_secret.resources | length > 0
-  - r_argocd_secret.resources[0].data is defined
-  - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') in r_argocd_secret.resources[0].data
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    api_version: v1
-    kind: Secret
-    name: argocd-secret
-    namespace: openshift-gitops
-    definition:
-      data: "{{ r_argocd_secret.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') | items2dict }}"
+  - name: Remove user password from argocd-secret
+    when:
+    - r_argocd_secret.resources | length > 0
+    - r_argocd_secret.resources[0].data is defined
+    - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') in r_argocd_secret.resources[0].data
+    kubernetes.core.k8s:
+      state: present
+      api_version: v1
+      kind: Secret
+      name: argocd-secret
+      namespace: openshift-gitops
+      definition:
+        data: "{{ r_argocd_secret.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') | items2dict }}"

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
@@ -7,7 +7,7 @@
     state: absent
     api_version: argoproj.io/v1alpha1
     kind: AppProject
-    name: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}{{ ocp4_workload_tenant_openshift_gitops_user }}"
+    name: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
     namespace: openshift-gitops
 
 - name: Get current argocd-cm ConfigMap

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -1,0 +1,96 @@
+---
+- name: Create tenant AppProject for {{ ocp4_workload_tenant_openshift_gitops_user }}
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'appproject-user.yaml.j2') }}"
+
+- name: Get current argocd-cm ConfigMap
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: argocd-cm
+    namespace: openshift-gitops
+  register: r_argocd_cm
+
+- name: Add user account to argocd-cm
+  kubernetes.core.k8s:
+    state: patched
+    api_version: v1
+    kind: ConfigMap
+    name: argocd-cm
+    namespace: openshift-gitops
+    definition:
+      data:
+        accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}: "apiKey, login"
+
+- name: Generate bcrypt password hash for {{ ocp4_workload_tenant_openshift_gitops_user }}
+  ansible.builtin.shell: |
+    htpasswd -nbBC 10 {{ ocp4_workload_tenant_openshift_gitops_user }} {{ ocp4_workload_tenant_openshift_gitops_user_password }} | cut -d: -f2
+  register: r_password_hash
+  no_log: true
+
+- name: Set password for {{ ocp4_workload_tenant_openshift_gitops_user }} in argocd-secret
+  kubernetes.core.k8s:
+    state: patched
+    api_version: v1
+    kind: Secret
+    name: argocd-secret
+    namespace: openshift-gitops
+    definition:
+      stringData:
+        accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password: "{{ r_password_hash.stdout }}"
+  no_log: true
+
+- name: Get current argocd-rbac-cm ConfigMap
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: argocd-rbac-cm
+    namespace: openshift-gitops
+  register: r_argocd_rbac_cm
+
+- name: Set current RBAC policy
+  ansible.builtin.set_fact:
+    _current_rbac_policy: "{{ r_argocd_rbac_cm.resources[0].data['policy.csv'] | default('') }}"
+  when: r_argocd_rbac_cm.resources | length > 0
+
+- name: Set empty RBAC policy if ConfigMap doesn't exist
+  ansible.builtin.set_fact:
+    _current_rbac_policy: ""
+  when: r_argocd_rbac_cm.resources | length == 0
+
+- name: Configure RBAC for {{ ocp4_workload_tenant_openshift_gitops_user }}
+  kubernetes.core.k8s:
+    state: present
+    api_version: v1
+    kind: ConfigMap
+    name: argocd-rbac-cm
+    namespace: openshift-gitops
+    definition:
+      data:
+        policy.csv: |
+          {{ _current_rbac_policy }}
+          g, {{ ocp4_workload_tenant_openshift_gitops_user }}, role:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}{{ ocp4_workload_tenant_openshift_gitops_user }}
+
+- name: Get the OpenShift GitOps ArgoCD server route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: openshift-gitops-server
+    namespace: openshift-gitops
+  register: r_openshift_gitops_server_route
+
+- name: Set ArgoCD URL fact
+  ansible.builtin.set_fact:
+    _ocp4_workload_tenant_openshift_gitops_url: "https://{{ r_openshift_gitops_server_route.resources[0].spec.host }}"
+
+# yamllint disable rule:line-length
+- name: Save AgnosticD user data
+  agnosticd.core.agnosticd_user_info:
+    msg: "OpenShift GitOps AppProject created: {{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}{{ ocp4_workload_tenant_openshift_gitops_user }}"
+    data:
+      openshift_gitops_server: "{{ _ocp4_workload_tenant_openshift_gitops_url }}"
+      openshift_gitops_user: "{{ ocp4_workload_tenant_openshift_gitops_user }}"
+      openshift_gitops_password: "{{ ocp4_workload_tenant_openshift_gitops_user_password }}"
+      openshift_gitops_appproject: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}{{ ocp4_workload_tenant_openshift_gitops_user }}"
+# yamllint enable rule:line-length

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -1,11 +1,17 @@
 ---
 - name: Create tenant AppProject for {{ ocp4_workload_tenant_openshift_gitops_user }}
   kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     state: present
     definition: "{{ lookup('template', 'appproject-user.yaml.j2') }}"
 
 - name: Get current argocd-cm ConfigMap
   kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     api_version: v1
     kind: ConfigMap
     name: argocd-cm
@@ -14,6 +20,9 @@
 
 - name: Add user account to argocd-cm
   kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     state: patched
     api_version: v1
     kind: ConfigMap
@@ -31,6 +40,9 @@
 
 - name: Set password for {{ ocp4_workload_tenant_openshift_gitops_user }} in argocd-secret
   kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     state: patched
     api_version: v1
     kind: Secret
@@ -43,6 +55,9 @@
 
 - name: Get current argocd-rbac-cm ConfigMap
   kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     api_version: v1
     kind: ConfigMap
     name: argocd-rbac-cm
@@ -61,6 +76,9 @@
 
 - name: Configure RBAC for {{ ocp4_workload_tenant_openshift_gitops_user }}
   kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     state: present
     api_version: v1
     kind: ConfigMap
@@ -74,6 +92,9 @@
 
 - name: Get the OpenShift GitOps ArgoCD server route
   kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+    validate_certs: false
     api_version: route.openshift.io/v1
     kind: Route
     name: openshift-gitops-server

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -33,9 +33,8 @@
         accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}: "apiKey, login"
 
 - name: Generate bcrypt password hash for {{ ocp4_workload_tenant_openshift_gitops_user }}
-  ansible.builtin.shell: |
-    htpasswd -nbBC 10 {{ ocp4_workload_tenant_openshift_gitops_user }} {{ ocp4_workload_tenant_openshift_gitops_user_password }} | cut -d: -f2
-  register: r_password_hash
+  ansible.builtin.set_fact:
+    _password_hash: "{{ ocp4_workload_tenant_openshift_gitops_user_password | password_hash('bcrypt', rounds=10) }}"
   no_log: true
 
 - name: Set password for {{ ocp4_workload_tenant_openshift_gitops_user }} in argocd-secret
@@ -50,7 +49,7 @@
     namespace: openshift-gitops
     definition:
       stringData:
-        accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password: "{{ r_password_hash.stdout }}"
+        accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password: "{{ _password_hash }}"
   no_log: true
 
 - name: Get current argocd-rbac-cm ConfigMap
@@ -74,21 +73,23 @@
     _current_rbac_policy: ""
   when: r_argocd_rbac_cm.resources | length == 0
 
+- name: Build new RBAC policy line
+  ansible.builtin.set_fact:
+    _new_rbac_line: "g, {{ ocp4_workload_tenant_openshift_gitops_user }}, role:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
+
 - name: Configure RBAC for {{ ocp4_workload_tenant_openshift_gitops_user }}
   kubernetes.core.k8s:
     host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
     api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
     validate_certs: false
-    state: present
+    state: patched
     api_version: v1
     kind: ConfigMap
     name: argocd-rbac-cm
     namespace: openshift-gitops
     definition:
       data:
-        policy.csv: |
-          {{ _current_rbac_policy }}
-          g, {{ ocp4_workload_tenant_openshift_gitops_user }}, role:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}{{ ocp4_workload_tenant_openshift_gitops_user }}
+        policy.csv: "{{ (_current_rbac_policy.rstrip() + '\n' + _new_rbac_line) if _current_rbac_policy else _new_rbac_line }}"
 
 - name: Get the OpenShift GitOps ArgoCD server route
   kubernetes.core.k8s_info:
@@ -108,10 +109,10 @@
 # yamllint disable rule:line-length
 - name: Save AgnosticD user data
   agnosticd.core.agnosticd_user_info:
-    msg: "OpenShift GitOps AppProject created: {{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}{{ ocp4_workload_tenant_openshift_gitops_user }}"
+    msg: "OpenShift GitOps AppProject created: {{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
     data:
       openshift_gitops_server: "{{ _ocp4_workload_tenant_openshift_gitops_url }}"
       openshift_gitops_user: "{{ ocp4_workload_tenant_openshift_gitops_user }}"
       openshift_gitops_password: "{{ ocp4_workload_tenant_openshift_gitops_user_password }}"
-      openshift_gitops_appproject: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}{{ ocp4_workload_tenant_openshift_gitops_user }}"
+      openshift_gitops_appproject: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
 # yamllint enable rule:line-length

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -16,7 +16,7 @@
       api_version: v1
       kind: ConfigMap
       name: argocd-cm
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
     register: r_argocd_cm
 
   - name: Add user account to argocd-cm
@@ -25,7 +25,7 @@
       api_version: v1
       kind: ConfigMap
       name: argocd-cm
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       definition:
         data:
           accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}: "apiKey, login"
@@ -41,7 +41,7 @@
       api_version: v1
       kind: Secret
       name: argocd-secret
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       definition:
         stringData:
           accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password: "{{ _password_hash }}"
@@ -52,7 +52,7 @@
       api_version: v1
       kind: ConfigMap
       name: argocd-rbac-cm
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
     register: r_argocd_rbac_cm
 
   - name: Set current RBAC policy
@@ -75,7 +75,7 @@
       api_version: v1
       kind: ConfigMap
       name: argocd-rbac-cm
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       definition:
         data:
           policy.csv: "{{ (_current_rbac_policy.rstrip() + '\n' + _new_rbac_line) if _current_rbac_policy else _new_rbac_line }}"
@@ -85,7 +85,7 @@
       api_version: route.openshift.io/v1
       kind: Route
       name: openshift-gitops-server
-      namespace: openshift-gitops
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
     register: r_openshift_gitops_server_route
 
   - name: Set ArgoCD URL fact

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -1,118 +1,104 @@
 ---
-- name: Create tenant AppProject for {{ ocp4_workload_tenant_openshift_gitops_user }}
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition: "{{ lookup('template', 'appproject-user.yaml.j2') }}"
+- name: Configure tenant OpenShift GitOps access
+  module_defaults:
+    group/kubernetes.core.k8s:
+      host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
+      api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
+      validate_certs: false
+  block:
+  - name: Create tenant AppProject for {{ ocp4_workload_tenant_openshift_gitops_user }}
+    kubernetes.core.k8s:
+      state: present
+      definition: "{{ lookup('template', 'appproject-user.yaml.j2') }}"
 
-- name: Get current argocd-cm ConfigMap
-  kubernetes.core.k8s_info:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    api_version: v1
-    kind: ConfigMap
-    name: argocd-cm
-    namespace: openshift-gitops
-  register: r_argocd_cm
+  - name: Get current argocd-cm ConfigMap
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: ConfigMap
+      name: argocd-cm
+      namespace: openshift-gitops
+    register: r_argocd_cm
 
-- name: Add user account to argocd-cm
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    state: patched
-    api_version: v1
-    kind: ConfigMap
-    name: argocd-cm
-    namespace: openshift-gitops
-    definition:
+  - name: Add user account to argocd-cm
+    kubernetes.core.k8s:
+      state: patched
+      api_version: v1
+      kind: ConfigMap
+      name: argocd-cm
+      namespace: openshift-gitops
+      definition:
+        data:
+          accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}: "apiKey, login"
+
+  - name: Generate bcrypt password hash for {{ ocp4_workload_tenant_openshift_gitops_user }}
+    ansible.builtin.set_fact:
+      _password_hash: "{{ ocp4_workload_tenant_openshift_gitops_user_password | password_hash('bcrypt', rounds=10) }}"
+    no_log: true
+
+  - name: Set password for {{ ocp4_workload_tenant_openshift_gitops_user }} in argocd-secret
+    kubernetes.core.k8s:
+      state: patched
+      api_version: v1
+      kind: Secret
+      name: argocd-secret
+      namespace: openshift-gitops
+      definition:
+        stringData:
+          accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password: "{{ _password_hash }}"
+    no_log: true
+
+  - name: Get current argocd-rbac-cm ConfigMap
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: ConfigMap
+      name: argocd-rbac-cm
+      namespace: openshift-gitops
+    register: r_argocd_rbac_cm
+
+  - name: Set current RBAC policy
+    ansible.builtin.set_fact:
+      _current_rbac_policy: "{{ r_argocd_rbac_cm.resources[0].data['policy.csv'] | default('') }}"
+    when: r_argocd_rbac_cm.resources | length > 0
+
+  - name: Set empty RBAC policy if ConfigMap doesn't exist
+    ansible.builtin.set_fact:
+      _current_rbac_policy: ""
+    when: r_argocd_rbac_cm.resources | length == 0
+
+  - name: Build new RBAC policy line
+    ansible.builtin.set_fact:
+      _new_rbac_line: "g, {{ ocp4_workload_tenant_openshift_gitops_user }}, role:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
+
+  - name: Configure RBAC for {{ ocp4_workload_tenant_openshift_gitops_user }}
+    kubernetes.core.k8s:
+      state: patched
+      api_version: v1
+      kind: ConfigMap
+      name: argocd-rbac-cm
+      namespace: openshift-gitops
+      definition:
+        data:
+          policy.csv: "{{ (_current_rbac_policy.rstrip() + '\n' + _new_rbac_line) if _current_rbac_policy else _new_rbac_line }}"
+
+  - name: Get the OpenShift GitOps ArgoCD server route
+    kubernetes.core.k8s_info:
+      api_version: route.openshift.io/v1
+      kind: Route
+      name: openshift-gitops-server
+      namespace: openshift-gitops
+    register: r_openshift_gitops_server_route
+
+  - name: Set ArgoCD URL fact
+    ansible.builtin.set_fact:
+      _ocp4_workload_tenant_openshift_gitops_url: "https://{{ r_openshift_gitops_server_route.resources[0].spec.host }}"
+
+  # yamllint disable rule:line-length
+  - name: Save AgnosticD user data
+    agnosticd.core.agnosticd_user_info:
+      msg: "OpenShift GitOps AppProject created: {{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
       data:
-        accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}: "apiKey, login"
-
-- name: Generate bcrypt password hash for {{ ocp4_workload_tenant_openshift_gitops_user }}
-  ansible.builtin.set_fact:
-    _password_hash: "{{ ocp4_workload_tenant_openshift_gitops_user_password | password_hash('bcrypt', rounds=10) }}"
-  no_log: true
-
-- name: Set password for {{ ocp4_workload_tenant_openshift_gitops_user }} in argocd-secret
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    state: patched
-    api_version: v1
-    kind: Secret
-    name: argocd-secret
-    namespace: openshift-gitops
-    definition:
-      stringData:
-        accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password: "{{ _password_hash }}"
-  no_log: true
-
-- name: Get current argocd-rbac-cm ConfigMap
-  kubernetes.core.k8s_info:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    api_version: v1
-    kind: ConfigMap
-    name: argocd-rbac-cm
-    namespace: openshift-gitops
-  register: r_argocd_rbac_cm
-
-- name: Set current RBAC policy
-  ansible.builtin.set_fact:
-    _current_rbac_policy: "{{ r_argocd_rbac_cm.resources[0].data['policy.csv'] | default('') }}"
-  when: r_argocd_rbac_cm.resources | length > 0
-
-- name: Set empty RBAC policy if ConfigMap doesn't exist
-  ansible.builtin.set_fact:
-    _current_rbac_policy: ""
-  when: r_argocd_rbac_cm.resources | length == 0
-
-- name: Build new RBAC policy line
-  ansible.builtin.set_fact:
-    _new_rbac_line: "g, {{ ocp4_workload_tenant_openshift_gitops_user }}, role:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
-
-- name: Configure RBAC for {{ ocp4_workload_tenant_openshift_gitops_user }}
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    state: patched
-    api_version: v1
-    kind: ConfigMap
-    name: argocd-rbac-cm
-    namespace: openshift-gitops
-    definition:
-      data:
-        policy.csv: "{{ (_current_rbac_policy.rstrip() + '\n' + _new_rbac_line) if _current_rbac_policy else _new_rbac_line }}"
-
-- name: Get the OpenShift GitOps ArgoCD server route
-  kubernetes.core.k8s_info:
-    host: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_openshift_gitops_openshift_api_token }}"
-    validate_certs: false
-    api_version: route.openshift.io/v1
-    kind: Route
-    name: openshift-gitops-server
-    namespace: openshift-gitops
-  register: r_openshift_gitops_server_route
-
-- name: Set ArgoCD URL fact
-  ansible.builtin.set_fact:
-    _ocp4_workload_tenant_openshift_gitops_url: "https://{{ r_openshift_gitops_server_route.resources[0].spec.host }}"
-
-# yamllint disable rule:line-length
-- name: Save AgnosticD user data
-  agnosticd.core.agnosticd_user_info:
-    msg: "OpenShift GitOps AppProject created: {{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
-    data:
-      openshift_gitops_server: "{{ _ocp4_workload_tenant_openshift_gitops_url }}"
-      openshift_gitops_user: "{{ ocp4_workload_tenant_openshift_gitops_user }}"
-      openshift_gitops_password: "{{ ocp4_workload_tenant_openshift_gitops_user_password }}"
-      openshift_gitops_appproject: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
-# yamllint enable rule:line-length
+        openshift_gitops_server: "{{ _ocp4_workload_tenant_openshift_gitops_url }}"
+        openshift_gitops_user: "{{ ocp4_workload_tenant_openshift_gitops_user }}"
+        openshift_gitops_password: "{{ ocp4_workload_tenant_openshift_gitops_user_password }}"
+        openshift_gitops_appproject: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
+  # yamllint enable rule:line-length

--- a/roles/ocp4_workload_tenant_openshift_gitops/templates/appproject-user.yaml.j2
+++ b/roles/ocp4_workload_tenant_openshift_gitops/templates/appproject-user.yaml.j2
@@ -1,0 +1,27 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}
+  namespace: openshift-gitops
+  labels:
+    app.kubernetes.io/managed-by: agnosticd
+spec:
+  description: "Project for {{ ocp4_workload_tenant_openshift_gitops_user }}"
+  destinations:
+  - namespace: "{{ ocp4_workload_tenant_openshift_gitops_user }}-*"
+    server: https://kubernetes.default.svc
+  sourceRepos:
+  - "*"
+  clusterResourceWhitelist:
+{% for resource in ocp4_workload_tenant_openshift_gitops_user_cluster_resource_whitelist %}
+  - group: "{{ resource.group }}"
+    kind: {{ resource.kind }}
+{% endfor %}
+  roles:
+  - name: user-role
+    description: "Role for {{ ocp4_workload_tenant_openshift_gitops_user }}"
+    policies:
+    - p, proj:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}:user-role, applications, *, {{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}/*, allow
+    groups:
+    - "{{ ocp4_workload_tenant_openshift_gitops_user }}"

--- a/roles/ocp4_workload_tenant_openshift_gitops/templates/appproject-user.yaml.j2
+++ b/roles/ocp4_workload_tenant_openshift_gitops/templates/appproject-user.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: {{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}
-  namespace: openshift-gitops
+  namespace: {{ ocp4_workload_tenant_openshift_gitops_namespace }}
   labels:
     app.kubernetes.io/managed-by: agnosticd
 spec:


### PR DESCRIPTION
Creates AppProject with user authentication and RBAC for tenant-based GitOps workflows. Manages user accounts, passwords, and permissions in existing ArgoCD instances.