### PR TITLE
fix: properly evaluate Jinja2 variables in ConfigMap/Secret dictionar…

### DIFF
--- a/roles/ocp4_workload_tenant_openshift_gitops/README.md
+++ b/roles/ocp4_workload_tenant_openshift_gitops/README.md
@@ -6,7 +6,7 @@ Ansible role to configure tenant-scoped access to an existing OpenShift GitOps (
 
 - OpenShift GitOps operator already installed and running in `openshift-gitops` namespace
 - Cluster admin API credentials for the target cluster
-- Python passlib library (for bcrypt password hashing)
+- `htpasswd` command available (for bcrypt password hashing)
 
 ## Role Variables
 
@@ -23,7 +23,9 @@ Ansible role to configure tenant-scoped access to an existing OpenShift GitOps (
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ocp4_workload_tenant_openshift_gitops_user_project_prefix` | Prefix for AppProject name | `appproject-` |
+| `ocp4_workload_tenant_openshift_gitops_namespace` | Namespace where ArgoCD is installed | `openshift-gitops` |
+| `ocp4_workload_tenant_openshift_gitops_argocd_cr_name` | Name of the ArgoCD custom resource | `openshift-gitops` |
+| `ocp4_workload_tenant_openshift_gitops_user_project_prefix` | Prefix for AppProject name | `appproject` |
 | `ocp4_workload_tenant_openshift_gitops_user_cluster_resource_whitelist` | Cluster-scoped resources allowed in AppProject | `[{ group: "", kind: Namespace }]` |
 
 ## AppProject Naming
@@ -88,15 +90,15 @@ None
 ### Provision (`ACTION=provision`)
 
 1. **Creates AppProject** - Creates a tenant-scoped ArgoCD AppProject
-2. **Registers User Account** - Adds user account to ArgoCD configuration (`argocd-cm`)
-3. **Sets Password** - Generates bcrypt hash and stores in ArgoCD secret (`argocd-secret`)
-4. **Configures RBAC** - Maps user to AppProject role in ArgoCD RBAC (`argocd-rbac-cm`)
+2. **Registers User Account** - Patches ArgoCD CR to add user account at `/spec/extraConfig/accounts.<user>`
+3. **Sets Password** - Generates htpasswd bcrypt hash and stores in ArgoCD secret (`argocd-secret`)
+4. **Configures RBAC** - Patches ArgoCD CR to add user RBAC binding at `/spec/rbac/policy`
 5. **Outputs User Data** - Provides ArgoCD URL, username, password, and AppProject name
 
 ### Destroy (`ACTION=destroy`)
 
 1. **Removes AppProject** - Deletes the tenant's AppProject
-2. **Removes User Account** - Cleans up user account from `argocd-cm`
+2. **Removes User Account** - Removes user account from ArgoCD CR
 3. **Removes Password** - Cleans up password from `argocd-secret`
 
 ## User Access
@@ -134,7 +136,11 @@ ocp4_workload_tenant_openshift_gitops_user_cluster_resource_whitelist:
 
 ## RBAC Behavior
 
-The role **appends** to existing RBAC policy in `argocd-rbac-cm` using `state: patched`. This preserves other users' RBAC configurations.
+The role **appends** to existing RBAC policy in the ArgoCD CR at `/spec/rbac/policy`. The role reads the current policy, appends the new user's RBAC line, and replaces the entire policy value. This preserves other users' RBAC configurations while being multi-tenant safe.
+
+## Implementation Details
+
+This role patches the ArgoCD custom resource directly rather than ConfigMaps. This prevents the ArgoCD operator from reverting manual ConfigMap changes and ensures tenant configurations persist across operator reconciliation cycles.
 
 ## License
 

--- a/roles/ocp4_workload_tenant_openshift_gitops/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/defaults/main.yml
@@ -6,6 +6,9 @@ ocp4_workload_tenant_openshift_gitops_openshift_api_token: "{{ cluster_admin_agn
 # OpenShift GitOps namespace
 ocp4_workload_tenant_openshift_gitops_namespace: openshift-gitops
 
+# ArgoCD CR name
+ocp4_workload_tenant_openshift_gitops_argocd_cr_name: openshift-gitops
+
 # User to create AppProject for
 ocp4_workload_tenant_openshift_gitops_user: "user-{{ guid }}"
 

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/remove_workload.yml
@@ -14,27 +14,27 @@
       name: "{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
 
-  - name: Get current argocd-cm ConfigMap
+  - name: Get current ArgoCD CR
     kubernetes.core.k8s_info:
-      api_version: v1
-      kind: ConfigMap
-      name: argocd-cm
+      api_version: argoproj.io/v1beta1
+      kind: ArgoCD
+      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-    register: r_argocd_cm
+    register: r_argocd
 
-  - name: Remove user account from argocd-cm
+  - name: Remove user account from ArgoCD CR
     when:
-    - r_argocd_cm.resources | length > 0
-    - r_argocd_cm.resources[0].data is defined
-    - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) in r_argocd_cm.resources[0].data
-    kubernetes.core.k8s:
-      state: present
-      api_version: v1
-      kind: ConfigMap
-      name: argocd-cm
+    - r_argocd.resources | length > 0
+    - r_argocd.resources[0].spec.extraConfig is defined
+    - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) in r_argocd.resources[0].spec.extraConfig
+    kubernetes.core.k8s_json_patch:
+      api_version: argoproj.io/v1beta1
+      kind: ArgoCD
+      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-      definition:
-        data: "{{ r_argocd_cm.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user) | items2dict }}"
+      patch:
+      - op: remove
+        path: /spec/extraConfig/accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}
 
   - name: Get current argocd-secret Secret
     kubernetes.core.k8s_info:
@@ -49,11 +49,43 @@
     - r_argocd_secret.resources | length > 0
     - r_argocd_secret.resources[0].data is defined
     - ('accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') in r_argocd_secret.resources[0].data
-    kubernetes.core.k8s:
-      state: present
+    kubernetes.core.k8s_json_patch:
       api_version: v1
       kind: Secret
       name: argocd-secret
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-      definition:
-        data: "{{ r_argocd_secret.resources[0].data | dict2items | rejectattr('key', 'equalto', 'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user ~ '.password') | items2dict }}"
+      patch:
+      - op: remove
+        path: /data/accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password
+
+  - name: Build RBAC policy line to remove
+    ansible.builtin.set_fact:
+      _rbac_line_to_remove: "g, {{ ocp4_workload_tenant_openshift_gitops_user }}, role:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
+
+  - name: Get current RBAC policy from ArgoCD CR
+    ansible.builtin.set_fact:
+      _current_rbac_policy: "{{ r_argocd.resources[0].spec.rbac.policy | default('') }}"
+    when:
+    - r_argocd.resources | length > 0
+    - r_argocd.resources[0].spec.rbac is defined
+    - r_argocd.resources[0].spec.rbac.policy is defined
+
+  - name: Remove user RBAC line from policy
+    ansible.builtin.set_fact:
+      _updated_rbac_policy: "{{ _current_rbac_policy.split('\n') | reject('equalto', _rbac_line_to_remove) | join('\n') }}"
+    when: _current_rbac_policy is defined
+
+  - name: Update ArgoCD RBAC policy
+    when:
+    - _current_rbac_policy is defined
+    - _updated_rbac_policy is defined
+    - _current_rbac_policy != _updated_rbac_policy
+    kubernetes.core.k8s_json_patch:
+      api_version: argoproj.io/v1beta1
+      kind: ArgoCD
+      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
+      patch:
+      - op: replace
+        path: /spec/rbac/policy
+        value: "{{ _updated_rbac_policy }}"

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -11,47 +11,33 @@
       state: present
       definition: "{{ lookup('template', 'appproject-user.yaml.j2') }}"
 
-  - name: Get current argocd-cm ConfigMap
-    kubernetes.core.k8s_info:
-      api_version: v1
-      kind: ConfigMap
-      name: argocd-cm
-      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-    register: r_argocd_cm
-
-  - name: Build user account data for argocd-cm
-    ansible.builtin.set_fact:
-      _argocd_cm_user_data: "{{ {'accounts.' + ocp4_workload_tenant_openshift_gitops_user: 'apiKey, login'} }}"
-
   - name: Add user account to argocd-cm
-    kubernetes.core.k8s:
-      state: patched
+    kubernetes.core.k8s_json_patch:
       api_version: v1
       kind: ConfigMap
       name: argocd-cm
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-      definition:
-        data: "{{ _argocd_cm_user_data }}"
+      patch:
+      - op: add
+        path: /data/accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}
+        value: "apiKey, login"
 
-  - name: Generate bcrypt password hash for {{ ocp4_workload_tenant_openshift_gitops_user }}
-    ansible.builtin.set_fact:
-      _password_hash: "{{ ocp4_workload_tenant_openshift_gitops_user_password | password_hash('bcrypt', rounds=10) }}"
-    no_log: true
-
-  - name: Build password data for argocd-secret
-    ansible.builtin.set_fact:
-      _argocd_secret_password_data: "{{ {'accounts.' + ocp4_workload_tenant_openshift_gitops_user + '.password': _password_hash} }}"
+  - name: Generate HTPasswd hash for password
+    ansible.builtin.shell: |
+      htpasswd -nbBC 10 "" "{{ ocp4_workload_tenant_openshift_gitops_user_password }}" | tr -d ':\n'
+    register: r_htpasswd_hash
     no_log: true
 
   - name: Set password for {{ ocp4_workload_tenant_openshift_gitops_user }} in argocd-secret
-    kubernetes.core.k8s:
-      state: patched
+    kubernetes.core.k8s_json_patch:
       api_version: v1
       kind: Secret
       name: argocd-secret
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-      definition:
-        stringData: "{{ _argocd_secret_password_data }}"
+      patch:
+      - op: add
+        path: /data/accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password
+        value: "{{ r_htpasswd_hash.stdout | b64encode }}"
     no_log: true
 
   - name: Get current argocd-rbac-cm ConfigMap

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -15,7 +15,7 @@
     kubernetes.core.k8s_json_patch:
       api_version: argoproj.io/v1beta1
       kind: ArgoCD
-      namespace: "{{ code_red_breach_challenge_argo_customize_argo_namespace }}"
+      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       name: openshift-gitops
       patch:
         - op: add

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -19,6 +19,10 @@
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
     register: r_argocd_cm
 
+  - name: Build user account data for argocd-cm
+    ansible.builtin.set_fact:
+      _argocd_cm_user_data: "{{ {'accounts.' + ocp4_workload_tenant_openshift_gitops_user: 'apiKey, login'} }}"
+
   - name: Add user account to argocd-cm
     kubernetes.core.k8s:
       state: patched
@@ -27,12 +31,16 @@
       name: argocd-cm
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       definition:
-        data:
-          accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}: "apiKey, login"
+        data: "{{ _argocd_cm_user_data }}"
 
   - name: Generate bcrypt password hash for {{ ocp4_workload_tenant_openshift_gitops_user }}
     ansible.builtin.set_fact:
       _password_hash: "{{ ocp4_workload_tenant_openshift_gitops_user_password | password_hash('bcrypt', rounds=10) }}"
+    no_log: true
+
+  - name: Build password data for argocd-secret
+    ansible.builtin.set_fact:
+      _argocd_secret_password_data: "{{ {'accounts.' + ocp4_workload_tenant_openshift_gitops_user + '.password': _password_hash} }}"
     no_log: true
 
   - name: Set password for {{ ocp4_workload_tenant_openshift_gitops_user }} in argocd-secret
@@ -43,8 +51,7 @@
       name: argocd-secret
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       definition:
-        stringData:
-          accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password: "{{ _password_hash }}"
+        stringData: "{{ _argocd_secret_password_data }}"
     no_log: true
 
   - name: Get current argocd-rbac-cm ConfigMap

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -11,16 +11,16 @@
       state: present
       definition: "{{ lookup('template', 'appproject-user.yaml.j2') }}"
 
-  - name: Add user account to argocd-cm
+  - name: Add user account to ArgoCD CR
     kubernetes.core.k8s_json_patch:
-      api_version: v1
-      kind: ConfigMap
-      name: argocd-cm
+      api_version: argoproj.io/v1beta1
+      kind: ArgoCD
+      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       patch:
       - op: add
-        path: /data/accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}
-        value: "apiKey, login"
+        path: /spec/extraConfig/accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}
+        value: login
 
   - name: Generate HTPasswd hash for password
     ansible.builtin.shell: |
@@ -40,44 +40,44 @@
         value: "{{ r_htpasswd_hash.stdout | b64encode }}"
     no_log: true
 
-  - name: Get current argocd-rbac-cm ConfigMap
+  - name: Get current ArgoCD RBAC policy
     kubernetes.core.k8s_info:
-      api_version: v1
-      kind: ConfigMap
-      name: argocd-rbac-cm
+      api_version: argoproj.io/v1beta1
+      kind: ArgoCD
+      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-    register: r_argocd_rbac_cm
+    register: r_argocd
 
   - name: Set current RBAC policy
     ansible.builtin.set_fact:
-      _current_rbac_policy: "{{ r_argocd_rbac_cm.resources[0].data['policy.csv'] | default('') }}"
-    when: r_argocd_rbac_cm.resources | length > 0
+      _current_rbac_policy: "{{ r_argocd.resources[0].spec.rbac.policy | default('') }}"
+    when: r_argocd.resources | length > 0
 
-  - name: Set empty RBAC policy if ConfigMap doesn't exist
+  - name: Set empty RBAC policy if not defined
     ansible.builtin.set_fact:
       _current_rbac_policy: ""
-    when: r_argocd_rbac_cm.resources | length == 0
+    when: r_argocd.resources | length == 0 or r_argocd.resources[0].spec.rbac is not defined or r_argocd.resources[0].spec.rbac.policy is not defined
 
   - name: Build new RBAC policy line
     ansible.builtin.set_fact:
       _new_rbac_line: "g, {{ ocp4_workload_tenant_openshift_gitops_user }}, role:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
 
-  - name: Configure RBAC for {{ ocp4_workload_tenant_openshift_gitops_user }}
-    kubernetes.core.k8s:
-      state: patched
-      api_version: v1
-      kind: ConfigMap
-      name: argocd-rbac-cm
+  - name: Configure RBAC for {{ ocp4_workload_tenant_openshift_gitops_user }} in ArgoCD CR
+    kubernetes.core.k8s_json_patch:
+      api_version: argoproj.io/v1beta1
+      kind: ArgoCD
+      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-      definition:
-        data:
-          policy.csv: "{{ (_current_rbac_policy.rstrip() + '\n' + _new_rbac_line) if _current_rbac_policy else _new_rbac_line }}"
+      patch:
+      - op: replace
+        path: /spec/rbac/policy
+        value: "{{ (_current_rbac_policy.rstrip() + '\n' + _new_rbac_line) if _current_rbac_policy else _new_rbac_line }}"
 
   - name: Get the OpenShift GitOps ArgoCD server route
     kubernetes.core.k8s_info:
       api_version: route.openshift.io/v1
       kind: Route
-      name: openshift-gitops-server
+      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}-server"
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
     register: r_openshift_gitops_server_route
 

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -81,6 +81,9 @@
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       patch:
       - op: replace
+        path: /spec/rbac/defaultPolicy
+        value: ''
+      - op: replace
         path: /spec/rbac/policy
         value: "{{ (_current_rbac_policy.rstrip() + '\n' + _new_rbac_line) if _current_rbac_policy else _new_rbac_line }}"
 

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -11,6 +11,17 @@
       state: present
       definition: "{{ lookup('template', 'appproject-user.yaml.j2') }}"
 
+  - name: Add extraConfig to ArgoCD
+    kubernetes.core.k8s_json_patch:
+      api_version: argoproj.io/v1beta1
+      kind: ArgoCD
+      namespace: "{{ code_red_breach_challenge_argo_customize_argo_namespace }}"
+      name: openshift-gitops
+      patch:
+        - op: add
+          path: /spec/extraConfig
+          value: {}
+
   - name: Add user account to ArgoCD CR
     kubernetes.core.k8s_json_patch:
       api_version: argoproj.io/v1beta1

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -11,27 +11,17 @@
       state: present
       definition: "{{ lookup('template', 'appproject-user.yaml.j2') }}"
 
-  - name: Add extraConfig to ArgoCD
-    kubernetes.core.k8s_json_patch:
+  - name: Add user account to ArgoCD CR
+    kubernetes.core.k8s:
       api_version: argoproj.io/v1beta1
       kind: ArgoCD
       namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
       name: openshift-gitops
-      patch:
-        - op: add
-          path: /spec/extraConfig
-          value: {}
-
-  - name: Add user account to ArgoCD CR
-    kubernetes.core.k8s_json_patch:
-      api_version: argoproj.io/v1beta1
-      kind: ArgoCD
-      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
-      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-      patch:
-      - op: add
-        path: /spec/extraConfig/accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}
-        value: login
+      state: patched
+      definition:
+        spec:
+          extraConfig:
+            "accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}": "apiKey, login"
 
   - name: Generate HTPasswd hash for password
     ansible.builtin.shell: |
@@ -50,42 +40,6 @@
         path: /data/accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}.password
         value: "{{ r_htpasswd_hash.stdout | b64encode }}"
     no_log: true
-
-  - name: Get current ArgoCD RBAC policy
-    kubernetes.core.k8s_info:
-      api_version: argoproj.io/v1beta1
-      kind: ArgoCD
-      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
-      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-    register: r_argocd
-
-  - name: Set current RBAC policy
-    ansible.builtin.set_fact:
-      _current_rbac_policy: "{{ r_argocd.resources[0].spec.rbac.policy | default('') }}"
-    when: r_argocd.resources | length > 0
-
-  - name: Set empty RBAC policy if not defined
-    ansible.builtin.set_fact:
-      _current_rbac_policy: ""
-    when: r_argocd.resources | length == 0 or r_argocd.resources[0].spec.rbac is not defined or r_argocd.resources[0].spec.rbac.policy is not defined
-
-  - name: Build new RBAC policy line
-    ansible.builtin.set_fact:
-      _new_rbac_line: "g, {{ ocp4_workload_tenant_openshift_gitops_user }}, role:{{ ocp4_workload_tenant_openshift_gitops_user_project_prefix }}-{{ ocp4_workload_tenant_openshift_gitops_user }}"
-
-  - name: Configure RBAC for {{ ocp4_workload_tenant_openshift_gitops_user }} in ArgoCD CR
-    kubernetes.core.k8s_json_patch:
-      api_version: argoproj.io/v1beta1
-      kind: ArgoCD
-      name: "{{ ocp4_workload_tenant_openshift_gitops_argocd_cr_name }}"
-      namespace: "{{ ocp4_workload_tenant_openshift_gitops_namespace }}"
-      patch:
-      - op: replace
-        path: /spec/rbac/defaultPolicy
-        value: ''
-      - op: replace
-        path: /spec/rbac/policy
-        value: "{{ (_current_rbac_policy.rstrip() + '\n' + _new_rbac_line) if _current_rbac_policy else _new_rbac_line }}"
 
   - name: Get the OpenShift GitOps ArgoCD server route
     kubernetes.core.k8s_info:

--- a/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/tasks/workload.yml
@@ -20,8 +20,7 @@
       state: patched
       definition:
         spec:
-          extraConfig:
-            "accounts.{{ ocp4_workload_tenant_openshift_gitops_user }}": "apiKey, login"
+          extraConfig: "{{ {'accounts.' ~ ocp4_workload_tenant_openshift_gitops_user: 'apiKey, login'} }}"
 
   - name: Generate HTPasswd hash for password
     ansible.builtin.shell: |


### PR DESCRIPTION
…y keys

Build data dictionaries using set_fact before passing to k8s module to ensure variables are evaluated. Fixes error where literal "accounts.{{ variable }}" was sent to API instead of evaluated value.