### PR TITLE
fix: handle both remove and destroy ACTION in tenant_namespace

### DIFF
--- a/roles/ocp4_workload_tenant_namespace/tasks/main.yml
+++ b/roles/ocp4_workload_tenant_namespace/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Running workload tasks
-  when: ACTION | default('provision') == 'provision'
+  when: ACTION | default('provision') in ['provision', 'create']
   ansible.builtin.include_tasks: workload.yml
 
 - name: Running workload removal tasks
-  when: ACTION | default('provision') == 'remove'
+  when: ACTION | default('provision') in ['remove', 'destroy']
   ansible.builtin.include_tasks: remove_workload.yml


### PR DESCRIPTION
The role only checked `ACTION == 'remove'` but `config: namespace` runs destroy with `ACTION = 'destroy'`. Namespaces were being skipped on destroy. Added 'destroy' to provision and removal conditions.