### PR TITLE
Fix remove_workload to support both namespace config styles

### DIFF
--- a/roles/ocp4_workload_tenant_namespace/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_namespace/tasks/remove_workload.yml
@@ -1,5 +1,18 @@
 ---
-- name: Build namespace list
+# Build the namespace list from whichever style was used at provision time.
+# Style A uses ocp4_workload_tenant_namespace_namespaces (list of {suffix: ...} dicts).
+# Style B uses ocp4_workload_tenant_namespace_suffixes (plain list of strings).
+- name: Build namespace list (Style A — per-namespace config)
+  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length > 0
+  ansible.builtin.set_fact:
+    _tenant_namespaces: >-
+      {{ ocp4_workload_tenant_namespace_namespaces
+         | map(attribute='suffix')
+         | map('regex_replace', '^(.+)$', ocp4_workload_tenant_namespace_prefix + '-\1')
+         | list }}
+
+- name: Build namespace list (Style B — suffix list)
+  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length == 0
   ansible.builtin.set_fact:
     _tenant_namespaces: >-
       {{ ocp4_workload_tenant_namespace_suffixes


### PR DESCRIPTION
## Summary

- Add support for both namespace configuration styles in `remove_workload.yml`
- Style A: `ocp4_workload_tenant_namespace_namespaces` (list of dicts with `suffix` attribute)
- Style B: `ocp4_workload_tenant_namespace_suffixes` (plain list of strings)
- Ensures namespace cleanup works regardless of which style was used at provision time

## Changes

- Added conditional task "Build namespace list (Style A — per-namespace config)" that extracts suffixes from the namespace dict list
- Renamed existing task to "Build namespace list (Style B — suffix list)" with condition to only run when Style A is not in use