### PR TITLE
[ocp4_workload_tenant_namespace] Refactor to unified namespace model with CRQ support

### DIFF
--- a/roles/ocp4_workload_tenant_namespace/README.md
+++ b/roles/ocp4_workload_tenant_namespace/README.md
@@ -1,0 +1,26 @@
+# ocp4_workload_tenant_namespace
+
+Creates one or more OpenShift namespaces for a tenant user, applies resource controls, and grants RBAC access.
+
+## What it does
+
+- Creates namespaces named `{username}-{suffix}`, or a single namespace named after the user when no suffixes are defined
+- Applies a `LimitRange` to every namespace to set container resource defaults
+- Creates a `ClusterResourceQuota` (default) scoped to all tenant namespaces via a shared `tenant:` label, giving the user a flexible resource pool rather than fixed per-namespace caps
+- Grants the user the configured RBAC role in each namespace
+
+## Usage
+
+Set `ocp4_workload_tenant_namespace_username` and optionally define the namespaces to create:
+
+```yaml
+ocp4_workload_tenant_namespace_username: "user-{{ guid }}"
+
+ocp4_workload_tenant_namespace_suffixes:
+- suffix: myapp
+- suffix: mydb
+```
+
+Leave `suffixes` empty to create a single namespace named after the user.
+
+See [`defaults/main.yml`](defaults/main.yml) for all variables and their descriptions, including quota sizing and how to switch between ClusterResourceQuota and per-namespace ResourceQuota.

--- a/roles/ocp4_workload_tenant_namespace/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_namespace/defaults/main.yml
@@ -59,5 +59,5 @@ ocp4_workload_tenant_namespace_default_limit_range:
     cpu: "2"
     memory: 4Gi
   defaultRequest:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 250m
+    memory: 128Mi

--- a/roles/ocp4_workload_tenant_namespace/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_namespace/defaults/main.yml
@@ -3,47 +3,61 @@
 ocp4_workload_tenant_namespace_openshift_api_url: "{{ sandbox_openshift_api_url }}"
 ocp4_workload_tenant_namespace_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
 
-# User to grant access in each namespace
+# User granted access to each namespace and used as the namespace name/prefix.
 ocp4_workload_tenant_namespace_username: "user-{{ guid }}"
 
-# Role to bind for the user in each namespace
+# RBAC role bound to the user in each namespace.
 ocp4_workload_tenant_namespace_role: admin
 
-# Prefix prepended to each suffix: {suffix}-{prefix}
-# Defaults to ocp4_workload_tenant_namespace_username which defaults to user-{guid}
-ocp4_workload_tenant_namespace_prefix: "{{ ocp4_workload_tenant_namespace_username }}"
-
-# STYLE A — per-namespace config (supports different quota per namespace):
-# ocp4_workload_tenant_namespace_namespaces:
-# - suffix: librechat
-#   quota: { limits.cpu: "4", limits.memory: 8Gi }
-#   limit_range: { default: { cpu: 500m, memory: 1Gi }, defaultRequest: { cpu: 50m, memory: 128Mi } }
-# - suffix: mcp-gitea
-#   quota: { limits.cpu: "1", limits.memory: 2Gi }
-# - suffix: agent  # no per-ns config, uses global quota/limit_range
-ocp4_workload_tenant_namespace_namespaces: []
-
-# STYLE B — simple suffix list, all namespaces get same quota (backward compatible):
+# Namespaces to create. Leave empty to create a single namespace named after
+# the user (no suffix). Each entry requires 'suffix'. 'quota' and
+# 'limit_range' override the role defaults below and are only used when
+# use_cluster_quota is false.
+#
 # ocp4_workload_tenant_namespace_suffixes:
-# - librechat
-# - mcp-gitea
+# - suffix: myapp
+#   quota:
+#     limits.cpu: "4"
+#     requests.cpu: "4"
+#     limits.memory: 8Gi
+#     requests.memory: 8Gi
+#     requests.storage: 20Gi
+#   limit_range:
+#     default:
+#       cpu: "2"
+#       memory: 4Gi
+#     defaultRequest:
+#       cpu: 500m
+#       memory: 1Gi
+# - suffix: mydb   # no quota/limit_range — uses role defaults
 ocp4_workload_tenant_namespace_suffixes: []
 
-# ResourceQuota applied to each namespace (optional)
-# ocp4_workload_tenant_namespace_quota:
-#   limits.cpu: "2"
-#   requests.cpu: "2"
-#   limits.memory: 4Gi
-#   requests.memory: 4Gi
-#   requests.storage: 20Gi
-ocp4_workload_tenant_namespace_quota: {}
+# Use an OpenShift ClusterResourceQuota (CRQ) scoped to the tenant label.
+# This gives the user a shared resource pool across all their namespaces
+# rather than fixed per-namespace caps — useful when namespace boundaries
+# are not known at design time.
+# When false, a per-namespace ResourceQuota is applied instead.
+ocp4_workload_tenant_namespace_use_cluster_quota: true
 
-# LimitRange container defaults applied to each namespace (optional)
-# ocp4_workload_tenant_namespace_limit_range:
-#   default:
-#     cpu: 500m
-#     memory: 512Mi
-#   defaultRequest:
-#     cpu: 50m
-#     memory: 128Mi
-ocp4_workload_tenant_namespace_limit_range: {}
+# Total resource pool for the tenant.
+# Used as ClusterResourceQuota hard limits when use_cluster_quota is true,
+# or as the default per-namespace ResourceQuota when use_cluster_quota is false
+# and no per-namespace quota is defined in the suffix entry.
+ocp4_workload_tenant_namespace_default_quota:
+  limits.cpu: "4"
+  requests.cpu: "4"
+  limits.memory: 8Gi
+  requests.memory: 8Gi
+  requests.storage: 50Gi
+
+# LimitRange applied to every namespace.
+# Sized to allow 1-2 large pods — the default and max are intentionally high
+# so that containers without explicit resource specs still get useful limits
+# without artificially capping beefy workloads.
+ocp4_workload_tenant_namespace_default_limit_range:
+  default:
+    cpu: "2"
+    memory: 4Gi
+  defaultRequest:
+    cpu: 500m
+    memory: 1Gi

--- a/roles/ocp4_workload_tenant_namespace/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_namespace/tasks/remove_workload.yml
@@ -1,30 +1,59 @@
 ---
-# Build the namespace list from whichever style was used at provision time.
-# Style A uses ocp4_workload_tenant_namespace_namespaces (list of {suffix: ...} dicts).
-# Style B uses ocp4_workload_tenant_namespace_suffixes (plain list of strings).
-- name: Build namespace list (Style A — per-namespace config)
-  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length > 0
+# -----------------------------------------------------------------------
+# Build the same namespace list used at provision time so we know exactly
+# what to delete. This must stay in sync with workload.yml logic.
+# -----------------------------------------------------------------------
+- name: Initialize namespace list
+  ansible.builtin.set_fact:
+    _tenant_namespaces: []
+
+- name: Build namespace list — single namespace
+  when: ocp4_workload_tenant_namespace_suffixes | length == 0
+  ansible.builtin.set_fact:
+    _tenant_namespaces:
+      - name: "{{ ocp4_workload_tenant_namespace_username }}"
+
+- name: Build namespace list — from suffix entries
+  when: ocp4_workload_tenant_namespace_suffixes | length > 0
   ansible.builtin.set_fact:
     _tenant_namespaces: >-
-      {{ ocp4_workload_tenant_namespace_namespaces
-         | map(attribute='suffix')
-         | map('regex_replace', '^(.+)$', ocp4_workload_tenant_namespace_prefix + '-\1')
-         | list }}
+      {{ _tenant_namespaces + [{'name': ocp4_workload_tenant_namespace_username ~ '-' ~ item.suffix}] }}
+  loop: "{{ ocp4_workload_tenant_namespace_suffixes }}"
+  loop_control:
+    label: "{{ item.suffix }}"
 
-- name: Build namespace list (Style B — suffix list)
-  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length == 0
-  ansible.builtin.set_fact:
-    _tenant_namespaces: >-
-      {{ ocp4_workload_tenant_namespace_suffixes
-         | map('regex_replace', '^(.+)$', ocp4_workload_tenant_namespace_prefix + '-\1')
-         | list }}
+# -----------------------------------------------------------------------
+# Delete ClusterResourceQuota first.
+# Removing quota enforcement before namespace termination avoids any
+# edge cases where finalizer-driven object deletion is blocked by quota.
+# -----------------------------------------------------------------------
+- name: Delete ClusterResourceQuota for tenant
+  when: ocp4_workload_tenant_namespace_use_cluster_quota | bool
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
+    validate_certs: false
+    state: absent
+    api_version: quota.openshift.io/v1
+    kind: ClusterResourceQuota
+    name: "tenant-{{ ocp4_workload_tenant_namespace_username }}"
+    wait: true
+    wait_timeout: 60
 
+# -----------------------------------------------------------------------
+# Trigger deletion of all namespaces without waiting so they terminate
+# in parallel on the cluster side.
+#
 # ArgoCD cleanup is handled by ocp4_workload_gitops_bootstrap remove_workload.
-# The bootstrap Application has resources-finalizer.argocd.argoproj.io so
-# deleting it cascades to child Applications and their K8s resources.
+# The bootstrap Application carries resources-finalizer.argocd.argoproj.io
+# so deleting it cascades to child Applications and their resources.
 # By the time this role runs, ArgoCD has already cleaned up.
-
-- name: Delete tenant namespaces
+#
+# NOTE: Do NOT set ignore_errors here. Failure to initiate deletion of a
+# namespace on a long-lived shared cluster is a real problem that must be
+# surfaced and resolved, not silently skipped.
+# -----------------------------------------------------------------------
+- name: Trigger tenant namespace deletion
   kubernetes.core.k8s:
     host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
     api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
@@ -32,8 +61,30 @@
     state: absent
     api_version: v1
     kind: Namespace
-    name: "{{ ns_item }}"
+    name: "{{ item.name }}"
   loop: "{{ _tenant_namespaces }}"
   loop_control:
-    loop_var: ns_item
-  ignore_errors: true
+    label: "{{ item.name }}"
+
+# -----------------------------------------------------------------------
+# Wait for each namespace to be fully terminated.
+# Namespaces terminated in parallel above; polling here confirms each is
+# truly gone before we consider cleanup complete.
+# A stuck namespace (e.g. hung finalizer) will surface as a task failure
+# rather than being silently left behind.
+# -----------------------------------------------------------------------
+- name: Wait for tenant namespace to be fully removed
+  kubernetes.core.k8s_info:
+    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
+    validate_certs: false
+    api_version: v1
+    kind: Namespace
+    name: "{{ item.name }}"
+  register: _ns_check
+  until: _ns_check.resources | length == 0
+  retries: 30
+  delay: 10
+  loop: "{{ _tenant_namespaces }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/ocp4_workload_tenant_namespace/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_namespace/tasks/workload.yml
@@ -1,121 +1,45 @@
 ---
-# ==================================================================
-# Create tenant namespaces with optional per-namespace quota/limits.
-# Pattern: {prefix}-{suffix}  e.g. mcpuser-guid-librechat
+# -----------------------------------------------------------------------
+# Build _tenant_namespaces — a list of dicts with keys:
+#   name        — full namespace name
+#   quota       — ResourceQuota hard limits (ignored when use_cluster_quota)
+#   limit_range — LimitRange container defaults
 #
-# STYLE A — per-namespace quota (new):
-#   ocp4_workload_tenant_namespace_namespaces:
-#   - suffix: librechat
-#     quota:       { limits.cpu: "4", limits.memory: 8Gi }
-#     limit_range: { default: { cpu: 500m, memory: 1Gi },
-#                    defaultRequest: { cpu: 50m, memory: 128Mi } }
-#   - suffix: mcp-gitea
-#     quota:       { limits.cpu: "1", limits.memory: 2Gi }
-#   - suffix: agent   # no per-ns config — falls back to global
-#
-# STYLE B — shared quota for all (backward compatible, existing syntax):
-#   ocp4_workload_tenant_namespace_suffixes: [librechat, mcp-gitea, agent]
-#   ocp4_workload_tenant_namespace_quota: { limits.cpu: "2", ... }
-#   ocp4_workload_tenant_namespace_limit_range: { default: { ... } }
-# ==================================================================
+# Two modes:
+#   • ocp4_workload_tenant_namespace_suffixes is empty
+#       → single namespace named after the user
+#   • ocp4_workload_tenant_namespace_suffixes has entries
+#       → one namespace per entry: {username}-{suffix}
+# -----------------------------------------------------------------------
+- name: Initialize namespace list
+  ansible.builtin.set_fact:
+    _tenant_namespaces: []
 
-# ------------------------------------------------------------------
-# STYLE A — per-namespace configuration
-# ------------------------------------------------------------------
-- name: "[Style A] Create namespace"
-  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length > 0
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ ocp4_workload_tenant_namespace_prefix }}-{{ item.suffix }}"
-        labels:
-          created-by: agnosticd
-          tenant: "{{ ocp4_workload_tenant_namespace_prefix }}"
-  loop: "{{ ocp4_workload_tenant_namespace_namespaces }}"
+- name: Build namespace list — single namespace (no suffixes defined)
+  when: ocp4_workload_tenant_namespace_suffixes | length == 0
+  ansible.builtin.set_fact:
+    _tenant_namespaces:
+      - name: "{{ ocp4_workload_tenant_namespace_username }}"
+        quota: "{{ ocp4_workload_tenant_namespace_default_quota }}"
+        limit_range: "{{ ocp4_workload_tenant_namespace_default_limit_range }}"
 
-- name: "[Style A] Apply ResourceQuota"
-  when:
-  - ocp4_workload_tenant_namespace_namespaces | default([]) | length > 0
-  - (item.quota | default(ocp4_workload_tenant_namespace_quota)) | length > 0
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition:
-      apiVersion: v1
-      kind: ResourceQuota
-      metadata:
-        name: tenant-quota
-        namespace: "{{ ocp4_workload_tenant_namespace_prefix }}-{{ item.suffix }}"
-      spec:
-        hard: "{{ item.quota | default(ocp4_workload_tenant_namespace_quota) }}"
-  loop: "{{ ocp4_workload_tenant_namespace_namespaces }}"
-
-- name: "[Style A] Apply LimitRange"
-  when:
-  - ocp4_workload_tenant_namespace_namespaces | default([]) | length > 0
-  - (item.limit_range | default(ocp4_workload_tenant_namespace_limit_range)) | length > 0
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition:
-      apiVersion: v1
-      kind: LimitRange
-      metadata:
-        name: tenant-limit-range
-        namespace: "{{ ocp4_workload_tenant_namespace_prefix }}-{{ item.suffix }}"
-      spec:
-        limits:
-        - type: Container
-          default: "{{ (item.limit_range | default(ocp4_workload_tenant_namespace_limit_range)).default | default({}) }}"
-          defaultRequest: "{{ (item.limit_range | default(ocp4_workload_tenant_namespace_limit_range)).defaultRequest | default({}) }}"
-  loop: "{{ ocp4_workload_tenant_namespace_namespaces }}"
-
-- name: "[Style A] Grant user access"
-  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length > 0
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        name: "{{ ocp4_workload_tenant_namespace_role }}-{{ ocp4_workload_tenant_namespace_username }}"
-        namespace: "{{ ocp4_workload_tenant_namespace_prefix }}-{{ item.suffix }}"
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: "{{ ocp4_workload_tenant_namespace_role }}"
-      subjects:
-      - apiGroup: rbac.authorization.k8s.io
-        kind: User
-        name: "{{ ocp4_workload_tenant_namespace_username }}"
-  loop: "{{ ocp4_workload_tenant_namespace_namespaces }}"
-
-# ------------------------------------------------------------------
-# STYLE B — simple suffix list (backward compatible)
-# ------------------------------------------------------------------
-- name: "[Style B] Build namespace list from suffixes"
-  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length == 0
+- name: Build namespace list — from suffix entries
+  when: ocp4_workload_tenant_namespace_suffixes | length > 0
   ansible.builtin.set_fact:
     _tenant_namespaces: >-
-      {{ ocp4_workload_tenant_namespace_suffixes
-         | map('regex_replace', '^(.+)$', ocp4_workload_tenant_namespace_prefix + '-\1')
-         | list }}
+      {{ _tenant_namespaces + [{
+           'name': ocp4_workload_tenant_namespace_username ~ '-' ~ item.suffix,
+           'quota': item.quota | default(ocp4_workload_tenant_namespace_default_quota),
+           'limit_range': item.limit_range | default(ocp4_workload_tenant_namespace_default_limit_range)
+         }] }}
+  loop: "{{ ocp4_workload_tenant_namespace_suffixes }}"
+  loop_control:
+    label: "{{ item.suffix }}"
 
-- name: "[Style B] Create tenant namespaces"
-  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length == 0
+# -----------------------------------------------------------------------
+# Create namespaces — label with tenant for CRQ selector targeting
+# -----------------------------------------------------------------------
+- name: Create tenant namespace
   kubernetes.core.k8s:
     host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
     api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
@@ -125,39 +49,19 @@
       apiVersion: v1
       kind: Namespace
       metadata:
-        name: "{{ ns_item }}"
+        name: "{{ item.name }}"
         labels:
           created-by: agnosticd
-          tenant: "{{ ocp4_workload_tenant_namespace_prefix }}"
-  loop: "{{ _tenant_namespaces | default([]) }}"
+          tenant: "{{ ocp4_workload_tenant_namespace_username }}"
+  loop: "{{ _tenant_namespaces }}"
   loop_control:
-    loop_var: ns_item
+    label: "{{ item.name }}"
 
-- name: "[Style B] Apply ResourceQuota to all namespaces"
-  when:
-  - ocp4_workload_tenant_namespace_namespaces | default([]) | length == 0
-  - ocp4_workload_tenant_namespace_quota | length > 0
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition:
-      apiVersion: v1
-      kind: ResourceQuota
-      metadata:
-        name: tenant-quota
-        namespace: "{{ ns_item }}"
-      spec:
-        hard: "{{ ocp4_workload_tenant_namespace_quota }}"
-  loop: "{{ _tenant_namespaces | default([]) }}"
-  loop_control:
-    loop_var: ns_item
-
-- name: "[Style B] Apply LimitRange to all namespaces"
-  when:
-  - ocp4_workload_tenant_namespace_namespaces | default([]) | length == 0
-  - ocp4_workload_tenant_namespace_limit_range | length > 0
+# -----------------------------------------------------------------------
+# LimitRange — applied to every namespace regardless of quota mode.
+# Ensures containers without explicit resource specs get sensible limits.
+# -----------------------------------------------------------------------
+- name: Apply LimitRange to namespace
   kubernetes.core.k8s:
     host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
     api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
@@ -168,18 +72,63 @@
       kind: LimitRange
       metadata:
         name: tenant-limit-range
-        namespace: "{{ ns_item }}"
+        namespace: "{{ item.name }}"
       spec:
         limits:
         - type: Container
-          default: "{{ ocp4_workload_tenant_namespace_limit_range.default | default({}) }}"
-          defaultRequest: "{{ ocp4_workload_tenant_namespace_limit_range.defaultRequest | default({}) }}"
-  loop: "{{ _tenant_namespaces | default([]) }}"
+          default: "{{ item.limit_range.default | default({}) }}"
+          defaultRequest: "{{ item.limit_range.defaultRequest | default({}) }}"
+  loop: "{{ _tenant_namespaces }}"
   loop_control:
-    loop_var: ns_item
+    label: "{{ item.name }}"
 
-- name: "[Style B] Grant user access in each namespace"
-  when: ocp4_workload_tenant_namespace_namespaces | default([]) | length == 0
+# -----------------------------------------------------------------------
+# Quota — one ClusterResourceQuota (shared pool) or per-namespace
+# ResourceQuota depending on use_cluster_quota.
+# -----------------------------------------------------------------------
+- name: Create ClusterResourceQuota for tenant
+  when: ocp4_workload_tenant_namespace_use_cluster_quota | bool
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
+    validate_certs: false
+    state: present
+    definition:
+      apiVersion: quota.openshift.io/v1
+      kind: ClusterResourceQuota
+      metadata:
+        name: "tenant-{{ ocp4_workload_tenant_namespace_username }}"
+      spec:
+        quota:
+          hard: "{{ ocp4_workload_tenant_namespace_default_quota }}"
+        selector:
+          labels:
+            matchLabels:
+              tenant: "{{ ocp4_workload_tenant_namespace_username }}"
+
+- name: Apply ResourceQuota to namespace
+  when: not (ocp4_workload_tenant_namespace_use_cluster_quota | bool)
+  kubernetes.core.k8s:
+    host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
+    api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
+    validate_certs: false
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ResourceQuota
+      metadata:
+        name: tenant-quota
+        namespace: "{{ item.name }}"
+      spec:
+        hard: "{{ item.quota }}"
+  loop: "{{ _tenant_namespaces }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# -----------------------------------------------------------------------
+# RBAC — grant user admin access in each namespace
+# -----------------------------------------------------------------------
+- name: Grant user access in namespace
   kubernetes.core.k8s:
     host: "{{ ocp4_workload_tenant_namespace_openshift_api_url }}"
     api_key: "{{ ocp4_workload_tenant_namespace_openshift_api_token }}"
@@ -190,7 +139,7 @@
       kind: RoleBinding
       metadata:
         name: "{{ ocp4_workload_tenant_namespace_role }}-{{ ocp4_workload_tenant_namespace_username }}"
-        namespace: "{{ ns_item }}"
+        namespace: "{{ item.name }}"
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -199,6 +148,6 @@
       - apiGroup: rbac.authorization.k8s.io
         kind: User
         name: "{{ ocp4_workload_tenant_namespace_username }}"
-  loop: "{{ _tenant_namespaces | default([]) }}"
+  loop: "{{ _tenant_namespaces }}"
   loop_control:
-    loop_var: ns_item
+    label: "{{ item.name }}"


### PR DESCRIPTION
## Summary

- Replace the Style A/B dual-path variable design with a single `ocp4_workload_tenant_namespace_suffixes` list; an empty list creates one namespace named after the user
- Add `ClusterResourceQuota` support (`use_cluster_quota: true` by default), giving tenants a shared resource pool across all namespaces instead of fixed per-namespace caps
- Remove `ocp4_workload_tenant_namespace_prefix`, `_namespaces`, `_quota`, and `_limit_range` variables; replaced by `default_quota` and `default_limit_range` with real values sized for large pods (4 CPU / 8Gi pool, 2 CPU / 4Gi container limit)
- Harden `remove_workload`: drop `ignore_errors`, delete CRQ first, trigger all namespace deletions in parallel, then poll with `k8s_info` until each is fully terminated

## Changes

### `defaults/main.yml`
- Removed: `_prefix`, `_namespaces`, `_suffixes` (old plain list), `_quota`, `_limit_range`
- Added: unified `_suffixes` (list of dicts with optional `quota`/`limit_range`), `use_cluster_quota`, `default_quota`, `default_limit_range` with real values

### `tasks/workload.yml`
- Replaced Style A/B branching with a single `_tenant_namespaces` build step
- Added `ClusterResourceQuota` creation task (scoped by `tenant:` label)
- Per-namespace `ResourceQuota` only applied when `use_cluster_quota: false`
- Removed dead `when: item.quota | length > 0` and `when: item.limit_range | length > 0` guards

### `tasks/remove_workload.yml`
- Removed `ignore_errors: true`
- Delete CRQ before namespaces to clear quota enforcement during teardown
- Trigger all namespace deletions (no wait), then poll each with `k8s_info` until fully terminated — surfaces stuck namespaces as failures rather than silently leaving resources behind on shared clusters