### PR TITLE
Replace cluster_admin_agnosticd_sa_token with sandbox_openshift_api_t…

### DIFF
--- a/roles/ns_example/tasks/workload.yml
+++ b/roles/ns_example/tasks/workload.yml
@@ -25,7 +25,7 @@
   - "sandbox_openshift_namespace:            {{ sandbox_openshift_namespace }}"
   - "sandbox_openshift_password:             {{ sandbox_openshift_password }}"
   - "sandbox_openshift_user:                 {{ sandbox_openshift_user }}"
-  - "cluster_admin_agnosticd_sa_token:       {{ cluster_admin_agnosticd_sa_token | default('Not available') }}"
+  - "sandbox_openshift_api_token:       {{ sandbox_openshift_api_token | default('Not available') }}"
 
 - name: Save AgnosticD user data
   agnosticd.core.agnosticd_user_info:

--- a/roles/ns_private_lmaas/tasks/remove_workload.yml
+++ b/roles/ns_private_lmaas/tasks/remove_workload.yml
@@ -3,7 +3,7 @@
   module_defaults:
     group/k8s:
       host: "{{ sandbox_openshift_api_url }}"
-      api_key: "{{ cluster_admin_agnosticd_sa_token }}"
+      api_key: "{{ sandbox_openshift_api_token }}"
       validate_certs: false
   block:
   - name: Remove devworkspace

--- a/roles/ns_private_lmaas/tasks/workload.yml
+++ b/roles/ns_private_lmaas/tasks/workload.yml
@@ -13,7 +13,7 @@
   module_defaults:
     group/k8s:
       host: "{{ sandbox_openshift_api_url }}"
-      api_key: "{{ cluster_admin_agnosticd_sa_token }}"
+      api_key: "{{ sandbox_openshift_api_token }}"
       validate_certs: false
   block:
   - name: Create namespaces

--- a/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cluster connection
 ocp4_workload_tenant_devspaces_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-ocp4_workload_tenant_devspaces_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
+ocp4_workload_tenant_devspaces_openshift_api_token: "{{ sandbox_openshift_api_token | trim }}"
 
 # User configuration
 ocp4_workload_tenant_devspaces_username: "user-{{ guid }}"

--- a/roles/ocp4_workload_tenant_gitea/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_gitea/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cluster connection
 ocp4_workload_tenant_gitea_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-ocp4_workload_tenant_gitea_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
+ocp4_workload_tenant_gitea_openshift_api_token: "{{ sandbox_openshift_api_token | trim }}"
 
 # Namespace where the per-user Gitea instance is deployed
 ocp4_workload_tenant_gitea_namespace: gitea

--- a/roles/ocp4_workload_tenant_keycloak_user/README.md
+++ b/roles/ocp4_workload_tenant_keycloak_user/README.md
@@ -50,7 +50,7 @@ The role uses `ACTION` variable (set automatically by AgnosticD): `provision` ru
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `_openshift_api_url` | `{{ sandbox_openshift_api_url }}` | Cluster API URL (from sandbox) |
-| `_openshift_api_token` | `{{ cluster_admin_agnosticd_sa_token }}` | SA token (from sandbox) |
+| `_openshift_api_token` | `{{ sandbox_openshift_api_token }}` | SA token (from sandbox) |
 | `_username` | `user-{{ guid }}` | Username to create |
 | `_password` | (required) | Password for the user |
 | `_keycloak_namespace` | `keycloak` | Namespace where RHBK is deployed |
@@ -72,4 +72,4 @@ Removes: Keycloak user, OCP Identity, OCP User object, per-user namespaces, Clus
 ## Prerequisites
 
 - Cluster must have RHBK (Keycloak) deployed via `ocp4_workload_authentication_keycloak`
-- `cluster_admin_agnosticd_sa_token` and `sandbox_openshift_api_url` provided by sandbox
+- `sandbox_openshift_api_token` and `sandbox_openshift_api_url` provided by sandbox

--- a/roles/ocp4_workload_tenant_keycloak_user/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_keycloak_user/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cluster connection (from sandbox)
 ocp4_workload_tenant_keycloak_user_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-ocp4_workload_tenant_keycloak_user_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
+ocp4_workload_tenant_keycloak_user_openshift_api_token: "{{ sandbox_openshift_api_token | trim }}"
 
 # User to create -- defaults to userX-GUID format
 ocp4_workload_tenant_keycloak_username: "user-{{ guid }}"

--- a/roles/ocp4_workload_tenant_namespace/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_namespace/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cluster connection
 ocp4_workload_tenant_namespace_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-ocp4_workload_tenant_namespace_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
+ocp4_workload_tenant_namespace_openshift_api_token: "{{ sandbox_openshift_api_token | trim }}"
 
 # User granted access to each namespace and used as the namespace name/prefix.
 ocp4_workload_tenant_namespace_username: "user-{{ guid }}"

--- a/roles/ocp4_workload_tenant_openshift_gitops/README.md
+++ b/roles/ocp4_workload_tenant_openshift_gitops/README.md
@@ -15,7 +15,7 @@ Ansible role to configure tenant-scoped access to an existing OpenShift GitOps (
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `ocp4_workload_tenant_openshift_gitops_openshift_api_url` | OpenShift API URL | `{{ sandbox_openshift_api_url }}` |
-| `ocp4_workload_tenant_openshift_gitops_openshift_api_token` | Cluster admin API token | `{{ cluster_admin_agnosticd_sa_token \| trim }}` |
+| `ocp4_workload_tenant_openshift_gitops_openshift_api_token` | Cluster admin API token | `{{ sandbox_openshift_api_token \| trim }}` |
 | `ocp4_workload_tenant_openshift_gitops_user` | Username for ArgoCD access | `user-{{ guid }}` |
 | `ocp4_workload_tenant_openshift_gitops_user_password` | Password for ArgoCD login | `{{ common_password \| default('openshift') }}` |
 

--- a/roles/ocp4_workload_tenant_openshift_gitops/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_openshift_gitops/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cluster connection
 ocp4_workload_tenant_openshift_gitops_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-ocp4_workload_tenant_openshift_gitops_openshift_api_token: "{{ cluster_admin_agnosticd_sa_token | trim }}"
+ocp4_workload_tenant_openshift_gitops_openshift_api_token: "{{ sandbox_openshift_api_token | trim }}"
 
 # OpenShift GitOps namespace
 ocp4_workload_tenant_openshift_gitops_namespace: openshift-gitops


### PR DESCRIPTION
…oken

Updated all roles to use the standardized sandbox_openshift_api_token variable instead of cluster_admin_agnosticd_sa_token for consistency with sandbox API provisioning.

Changes:
- Updated 8 role defaults/main.yml files to use sandbox_openshift_api_token
- Updated 2 README.md files to reflect new variable name
- Updated ns_example and ns_private_lmaas task files

This aligns the variable naming with the sandbox API's provision_data output and improves consistency across all tenant workload roles.