### PR TITLE
Add DevSpaces user info output and refactor module defaults

### DIFF
--- a/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
@@ -6,6 +6,9 @@ ocp4_workload_tenant_devspaces_openshift_api_token: "{{ cluster_admin_agnosticd_
 # User configuration
 ocp4_workload_tenant_devspaces_username: "user-{{ guid }}"
 
+# User password (will be overridden if provided from tenant_keycloak_user role)
+ocp4_workload_tenant_devspaces_user_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,punctuation length=16') }}"
+
 # Namespace (created by tenant_namespace role, passed as input)
 ocp4_workload_tenant_devspaces_namespace: "{{ ocp4_workload_tenant_devspaces_username }}-devworkspace"
 

--- a/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
@@ -3,18 +3,49 @@
 # Apply DevSpaces labels/annotations to namespace and create DevWorkspace
 # ==================================================================
 
-- name: Apply DevSpaces labels and annotations to namespace
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_devspaces_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_devspaces_openshift_api_token }}"
-    validate_certs: false
-    state: patched
-    definition: "{{ lookup('template', 'namespace.yml.j2') | from_yaml }}"
+- name: Setup DevSpaces for user
+  module_defaults:
+    group/kubernetes.core.k8s:
+      host: "{{ ocp4_workload_tenant_devspaces_openshift_api_url }}"
+      api_key: "{{ ocp4_workload_tenant_devspaces_openshift_api_token }}"
+      validate_certs: false
+  block:
+    - name: Apply DevSpaces labels and annotations to namespace
+      kubernetes.core.k8s:
+        state: patched
+        definition: "{{ lookup('template', 'namespace.yml.j2') | from_yaml }}"
 
-- name: Create DevWorkspace
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_devspaces_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_devspaces_openshift_api_token }}"
-    validate_certs: false
-    state: present
-    definition: "{{ lookup('template', 'devworkspace.yml.j2') | from_yaml }}"
+    - name: Create DevWorkspace
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('template', 'devworkspace.yml.j2') | from_yaml }}"
+
+    # ==================================================================
+    # Get DevSpaces URL and save user info
+    # ==================================================================
+
+    - name: Get DevSpaces dashboard route
+      kubernetes.core.k8s_info:
+        api_version: route.openshift.io/v1
+        kind: Route
+        name: devspaces
+        namespace: openshift-devspaces
+      register: r_devspaces_route
+
+    - name: Set DevSpaces URL fact
+      ansible.builtin.set_fact:
+        _ocp4_workload_tenant_devspaces_url: "https://{{ r_devspaces_route.resources[0].spec.host }}"
+
+    - name: Save DevSpaces user information
+      agnosticd.core.agnosticd_user_info:
+        data:
+          devspaces_url: "{{ _ocp4_workload_tenant_devspaces_url }}"
+          devspaces_username: "{{ ocp4_workload_tenant_devspaces_username }}"
+          devspaces_password: "{{ ocp4_workload_tenant_devspaces_user_password }}"
+
+    - name: Save DevSpaces user data for display
+      agnosticd.core.agnosticd_user_data:
+        data: |
+          DevSpaces IDE is available at: {{ _ocp4_workload_tenant_devspaces_url }}
+          Username: {{ ocp4_workload_tenant_devspaces_username }}
+          Password: {{ ocp4_workload_tenant_devspaces_user_password | default('[Password from Keycloak]') }}


### PR DESCRIPTION
Enhanced the tenant_devspaces role to provide user access information:

- Added module_defaults block for kubernetes.core.k8s group to DRY up connection parameters
- Retrieve DevSpaces dashboard route and construct user access URL
- Output structured data via agnosticd_user_info (devspaces_url, devspaces_username, devspaces_password)
- Output user-friendly display via agnosticd_user_data
- Added random password generation in defaults (16-char with letters, digits, punctuation)
- Password can be overridden by external sources (e.g., Keycloak user creation)

This enables automated provisioning workflows to capture and display DevSpaces access credentials.