### PR TITLE
Add embedded devfile support to ocp4_workload_tenant_devspaces

### DIFF
--- a/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
@@ -41,3 +41,37 @@ ocp4_workload_tenant_devspaces_devworkspace_components:
 - name: tooling
   container:
     image: registry.redhat.io/devspaces/udi-rhel8:latest
+
+# ==================================================================
+# Embedded Devfile Configuration
+# ==================================================================
+
+# Enable embedded devfile mode (creates DevWorkspaceTemplate + embeds devfile content)
+ocp4_workload_tenant_devspaces_use_embedded_devfile: false
+
+# URL to fetch devfile from (when embedded mode is enabled)
+# Example: https://gitea.example.com/user/repo/raw/branch/main/devfile.yaml
+ocp4_workload_tenant_devspaces_devfile_url: ""
+
+# DevWorkspaceTemplate name (for generic VS Code editor)
+ocp4_workload_tenant_devspaces_devworkspace_template_name: "che-code-{{ ocp4_workload_tenant_devspaces_username }}"
+
+# DevSpaces cluster URLs (auto-detected if not set)
+ocp4_workload_tenant_devspaces_dashboard_url: ""
+ocp4_workload_tenant_devspaces_plugin_registry_url: ""
+ocp4_workload_tenant_devspaces_plugin_registry_internal_url: ""
+ocp4_workload_tenant_devspaces_cluster_console_url: ""
+
+# VS Code editor image (used when embedded devfile is enabled)
+ocp4_workload_tenant_devspaces_che_code_image: "registry.redhat.io/devspaces/code-rhel9@sha256:5cd4fe568b4352bc5ef6ec0b16c3235fe515c2afb86fb076ed435cea65ea2247"
+ocp4_workload_tenant_devspaces_udi_image: "registry.redhat.io/devspaces/udi-rhel9@sha256:024712461154d505de3180f4459363c46bc5d0fe7465d7e270108540ce8902fe"
+
+# Environment variables to inject into devfile containers (when embedded mode is enabled)
+# Example:
+# ocp4_workload_tenant_devspaces_devfile_env_vars:
+# - name: GIT_USERNAME
+#   value: "{{ ocp4_workload_tenant_devspaces_username }}"
+ocp4_workload_tenant_devspaces_devfile_env_vars: []
+
+# SCC attribute for container builds
+ocp4_workload_tenant_devspaces_scc: "container-build"

--- a/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
@@ -56,13 +56,7 @@ ocp4_workload_tenant_devspaces_devfile_url: ""
 # DevWorkspaceTemplate name (for generic VS Code editor)
 ocp4_workload_tenant_devspaces_devworkspace_template_name: "che-code-{{ ocp4_workload_tenant_devspaces_username }}"
 
-# DevSpaces cluster URLs (auto-detected if not set)
-ocp4_workload_tenant_devspaces_dashboard_url: ""
-ocp4_workload_tenant_devspaces_plugin_registry_url: ""
-ocp4_workload_tenant_devspaces_plugin_registry_internal_url: ""
-ocp4_workload_tenant_devspaces_cluster_console_url: ""
-
-# VS Code editor image (used when embedded devfile is enabled)
+# VS Code editor images (used when embedded devfile is enabled)
 ocp4_workload_tenant_devspaces_che_code_image: "registry.redhat.io/devspaces/code-rhel9@sha256:5cd4fe568b4352bc5ef6ec0b16c3235fe515c2afb86fb076ed435cea65ea2247"
 ocp4_workload_tenant_devspaces_udi_image: "registry.redhat.io/devspaces/udi-rhel9@sha256:024712461154d505de3180f4459363c46bc5d0fe7465d7e270108540ce8902fe"
 

--- a/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
@@ -16,6 +16,9 @@ ocp4_workload_tenant_devspaces_namespace: "{{ ocp4_workload_tenant_devspaces_use
 ocp4_workload_tenant_devspaces_devworkspace_name: "{{ ocp4_workload_tenant_devspaces_username }}-workspace"
 
 # DevWorkspace devfile URL
+# - URI mode (use_embedded_devfile: false): Points to DevSpaces dashboard API for editor
+# - Embedded mode (use_embedded_devfile: true): Points to Git repository devfile
+# Example for embedded: http://gitea.gitea.svc:3000/user/repo/raw/branch/main/devfile.yaml
 ocp4_workload_tenant_devspaces_devworkspace_devfile: >-
   http://devspaces-dashboard.openshift-devspaces.svc.cluster.local:8080/dashboard/api/editors/devfile?che-editor=che-incubator/che-code/latest
 
@@ -48,10 +51,6 @@ ocp4_workload_tenant_devspaces_devworkspace_components:
 
 # Enable embedded devfile mode (creates DevWorkspaceTemplate + embeds devfile content)
 ocp4_workload_tenant_devspaces_use_embedded_devfile: false
-
-# URL to fetch devfile from (when embedded mode is enabled)
-# Example: https://gitea.example.com/user/repo/raw/branch/main/devfile.yaml
-ocp4_workload_tenant_devspaces_devfile_url: ""
 
 # DevWorkspaceTemplate name (for generic VS Code editor)
 ocp4_workload_tenant_devspaces_devworkspace_template_name: "che-code-{{ ocp4_workload_tenant_devspaces_username }}"

--- a/roles/ocp4_workload_tenant_devspaces/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/remove_workload.yml
@@ -15,22 +15,20 @@
         namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
       ignore_errors: true
 
-    - name: Delete DevWorkspaceTemplate (if embedded mode was used)
+    - name: Delete DevWorkspaceTemplate (if exists)
       kubernetes.core.k8s:
         state: absent
         api_version: workspace.devfile.io/v1alpha2
         kind: DevWorkspaceTemplate
         name: "{{ ocp4_workload_tenant_devspaces_devworkspace_template_name }}"
         namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
-      when: ocp4_workload_tenant_devspaces_use_embedded_devfile | bool
       ignore_errors: true
 
-    - name: Delete environment variables ConfigMap (if embedded mode was used)
+    - name: Delete environment variables ConfigMap (if exists)
       kubernetes.core.k8s:
         state: absent
         api_version: v1
         kind: ConfigMap
         name: "{{ ocp4_workload_tenant_devspaces_username }}-devworkspace-env"
         namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
-      when: ocp4_workload_tenant_devspaces_use_embedded_devfile | bool
       ignore_errors: true

--- a/roles/ocp4_workload_tenant_devspaces/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/remove_workload.yml
@@ -29,6 +29,6 @@
         state: absent
         api_version: v1
         kind: ConfigMap
-        name: "{{ ocp4_workload_tenant_devspaces_username }}-devworkspace-env"
+        name: devworkspace-env
         namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
       ignore_errors: true

--- a/roles/ocp4_workload_tenant_devspaces/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/remove_workload.yml
@@ -24,11 +24,11 @@
         namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
       ignore_errors: true
 
-    - name: Delete environment variables ConfigMap (if exists)
+    - name: Delete environment variables Secret (if exists)
       kubernetes.core.k8s:
         state: absent
         api_version: v1
-        kind: ConfigMap
+        kind: Secret
         name: devworkspace-env
         namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
       ignore_errors: true

--- a/roles/ocp4_workload_tenant_devspaces/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/remove_workload.yml
@@ -1,12 +1,36 @@
 ---
-- name: Delete DevWorkspace
-  kubernetes.core.k8s:
-    host: "{{ ocp4_workload_tenant_devspaces_openshift_api_url }}"
-    api_key: "{{ ocp4_workload_tenant_devspaces_openshift_api_token }}"
-    validate_certs: false
-    state: absent
-    api_version: workspace.devfile.io/v1alpha2
-    kind: DevWorkspace
-    name: "{{ ocp4_workload_tenant_devspaces_devworkspace_name }}"
-    namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
-  ignore_errors: true
+- name: Remove DevSpaces resources
+  module_defaults:
+    group/kubernetes.core.k8s:
+      host: "{{ ocp4_workload_tenant_devspaces_openshift_api_url }}"
+      api_key: "{{ ocp4_workload_tenant_devspaces_openshift_api_token }}"
+      validate_certs: false
+  block:
+    - name: Delete DevWorkspace
+      kubernetes.core.k8s:
+        state: absent
+        api_version: workspace.devfile.io/v1alpha2
+        kind: DevWorkspace
+        name: "{{ ocp4_workload_tenant_devspaces_devworkspace_name }}"
+        namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
+      ignore_errors: true
+
+    - name: Delete DevWorkspaceTemplate (if embedded mode was used)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: workspace.devfile.io/v1alpha2
+        kind: DevWorkspaceTemplate
+        name: "{{ ocp4_workload_tenant_devspaces_devworkspace_template_name }}"
+        namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
+      when: ocp4_workload_tenant_devspaces_use_embedded_devfile | bool
+      ignore_errors: true
+
+    - name: Delete environment variables ConfigMap (if embedded mode was used)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: ConfigMap
+        name: "{{ ocp4_workload_tenant_devspaces_username }}-devworkspace-env"
+        namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
+      when: ocp4_workload_tenant_devspaces_use_embedded_devfile | bool
+      ignore_errors: true

--- a/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
@@ -3,6 +3,7 @@
 # Setup Embedded Devfile Mode
 # ==================================================================
 # This task file handles:
+# - Creating Secret with environment variables (auto-mounted to workspace)
 # - Auto-detecting cluster URLs (dashboard, plugin registry, console)
 # - Fetching devfile from URL
 # - Stripping schemaVersion and metadata (not needed in template section)
@@ -52,10 +53,10 @@
       - "Plugin Registry Internal URL: {{ _devspaces_plugin_registry_internal_url }}"
       - "Console URL: {{ _devspaces_cluster_console_url }}"
 
-- name: Create ConfigMap with environment variables (auto-mounted to DevWorkspace)
+- name: Create Secret with environment variables (auto-mounted to DevWorkspace)
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template', 'configmap-env.yml.j2') | from_yaml }}"
+    definition: "{{ lookup('template', 'secret-env.yml.j2') | from_yaml }}"
   when: ocp4_workload_tenant_devspaces_devfile_env_vars | length > 0
 
 - name: Validate devfile URL is provided

--- a/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
@@ -36,20 +36,13 @@
 
 - name: Set auto-detected URLs
   ansible.builtin.set_fact:
-    _devspaces_dashboard_url: >-
-      {{ ocp4_workload_tenant_devspaces_dashboard_url
-         | default('https://' + r_dashboard_route.resources[0].spec.host) }}
+    _devspaces_dashboard_url: "https://{{ r_dashboard_route.resources[0].spec.host }}"
     _devspaces_plugin_registry_url: >-
-      {{ ocp4_workload_tenant_devspaces_plugin_registry_url
-         | default('https://' + r_plugin_registry_route.resources[0].spec.host + '/v3'
-                   if r_plugin_registry_route.resources | length > 0
-                   else 'https://' + r_dashboard_route.resources[0].spec.host.replace('devspaces', 'plugin-registry') + '/v3') }}
-    _devspaces_plugin_registry_internal_url: >-
-      {{ ocp4_workload_tenant_devspaces_plugin_registry_internal_url
-         | default('http://plugin-registry.openshift-devspaces.svc:8080/v3') }}
-    _devspaces_cluster_console_url: >-
-      {{ ocp4_workload_tenant_devspaces_cluster_console_url
-         | default('https://' + r_console_route.resources[0].spec.host) }}
+      {{ 'https://' + r_plugin_registry_route.resources[0].spec.host + '/v3'
+         if r_plugin_registry_route.resources | length > 0
+         else 'https://' + r_dashboard_route.resources[0].spec.host.replace('devspaces', 'plugin-registry') + '/v3' }}
+    _devspaces_plugin_registry_internal_url: "http://plugin-registry.openshift-devspaces.svc:8080/v3"
+    _devspaces_cluster_console_url: "https://{{ r_console_route.resources[0].spec.host }}"
 
 - name: Display auto-detected URLs
   ansible.builtin.debug:

--- a/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
@@ -1,0 +1,109 @@
+---
+# ==================================================================
+# Setup Embedded Devfile Mode
+# ==================================================================
+# This task file handles:
+# - Auto-detecting cluster URLs (dashboard, plugin registry, console)
+# - Fetching devfile from URL
+# - Stripping schemaVersion and metadata (not needed in template section)
+# - Creating DevWorkspaceTemplate for VS Code editor
+# ==================================================================
+
+- name: Get DevSpaces dashboard route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: devspaces
+    namespace: openshift-devspaces
+  register: r_dashboard_route
+
+- name: Get DevSpaces plugin-registry route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: plugin-registry
+    namespace: openshift-devspaces
+  register: r_plugin_registry_route
+  failed_when: false
+
+- name: Get OpenShift console route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: console
+    namespace: openshift-console
+  register: r_console_route
+
+- name: Set auto-detected URLs
+  ansible.builtin.set_fact:
+    _devspaces_dashboard_url: >-
+      {{ ocp4_workload_tenant_devspaces_dashboard_url
+         | default('https://' + r_dashboard_route.resources[0].spec.host) }}
+    _devspaces_plugin_registry_url: >-
+      {{ ocp4_workload_tenant_devspaces_plugin_registry_url
+         | default('https://' + r_plugin_registry_route.resources[0].spec.host + '/v3'
+                   if r_plugin_registry_route.resources | length > 0
+                   else 'https://' + r_dashboard_route.resources[0].spec.host.replace('devspaces', 'plugin-registry') + '/v3') }}
+    _devspaces_plugin_registry_internal_url: >-
+      {{ ocp4_workload_tenant_devspaces_plugin_registry_internal_url
+         | default('http://plugin-registry.openshift-devspaces.svc:8080/v3') }}
+    _devspaces_cluster_console_url: >-
+      {{ ocp4_workload_tenant_devspaces_cluster_console_url
+         | default('https://' + r_console_route.resources[0].spec.host) }}
+
+- name: Display auto-detected URLs
+  ansible.builtin.debug:
+    msg:
+      - "Dashboard URL: {{ _devspaces_dashboard_url }}"
+      - "Plugin Registry URL: {{ _devspaces_plugin_registry_url }}"
+      - "Plugin Registry Internal URL: {{ _devspaces_plugin_registry_internal_url }}"
+      - "Console URL: {{ _devspaces_cluster_console_url }}"
+
+- name: Create ConfigMap with environment variables (auto-mounted to DevWorkspace)
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'configmap-env.yml.j2') | from_yaml }}"
+  when: ocp4_workload_tenant_devspaces_devfile_env_vars | length > 0
+
+- name: Validate devfile URL is provided
+  ansible.builtin.assert:
+    that:
+      - ocp4_workload_tenant_devspaces_devfile_url | length > 0
+    fail_msg: "ocp4_workload_tenant_devspaces_devfile_url must be set when use_embedded_devfile is true"
+
+- name: Fetch devfile from URL
+  ansible.builtin.uri:
+    url: "{{ ocp4_workload_tenant_devspaces_devfile_url }}"
+    method: GET
+    return_content: true
+    validate_certs: false
+    status_code: [200]
+  register: r_devfile_content
+  retries: 3
+  delay: 5
+  until: r_devfile_content.status == 200
+
+- name: Parse devfile YAML content
+  ansible.builtin.set_fact:
+    _devfile_parsed: "{{ r_devfile_content.content | from_yaml }}"
+
+- name: Validate devfile structure
+  ansible.builtin.assert:
+    that:
+      - _devfile_parsed.schemaVersion is defined
+      - _devfile_parsed.metadata is defined
+    fail_msg: "Fetched content is not a valid devfile"
+
+- name: Prepare devfile for template section (strip metadata/schemaVersion only)
+  ansible.builtin.set_fact:
+    _devfile_template_content: >-
+      {{
+        _devfile_parsed | dict2items
+        | rejectattr('key', 'in', ['schemaVersion', 'metadata'])
+        | items2dict
+      }}
+
+- name: Create DevWorkspaceTemplate for VS Code editor
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'devworkspace-template.yml.j2') | from_yaml }}"

--- a/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
@@ -72,8 +72,8 @@
     validate_certs: false
     status_code: [200]
   register: r_devfile_content
-  retries: 3
-  delay: 5
+  retries: 12
+  delay: 10
   until: r_devfile_content.status == 200
 
 - name: Parse devfile YAML content

--- a/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/setup_embedded_devfile.yml
@@ -61,19 +61,19 @@
 - name: Validate devfile URL is provided
   ansible.builtin.assert:
     that:
-      - ocp4_workload_tenant_devspaces_devfile_url | length > 0
-    fail_msg: "ocp4_workload_tenant_devspaces_devfile_url must be set when use_embedded_devfile is true"
+      - ocp4_workload_tenant_devspaces_devworkspace_devfile | length > 0
+    fail_msg: "ocp4_workload_tenant_devspaces_devworkspace_devfile must be set when use_embedded_devfile is true"
 
 - name: Fetch devfile from URL
   ansible.builtin.uri:
-    url: "{{ ocp4_workload_tenant_devspaces_devfile_url }}"
+    url: "{{ ocp4_workload_tenant_devspaces_devworkspace_devfile }}"
     method: GET
     return_content: true
     validate_certs: false
     status_code: [200]
   register: r_devfile_content
-  retries: 12
-  delay: 10
+  retries: 3
+  delay: 5
   until: r_devfile_content.status == 200
 
 - name: Parse devfile YAML content

--- a/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
@@ -57,9 +57,8 @@
         - r_devworkspace.resources | length > 0
         - r_devworkspace.resources[0].status.mainUrl is defined
 
-    - name: Set DevWorkspace URLs
+    - name: Set DevWorkspace dashboard URL
       ansible.builtin.set_fact:
-        _ocp4_workload_tenant_devspaces_workspace_url: "{{ r_devworkspace.resources[0].status.mainUrl }}"
         _ocp4_workload_tenant_devspaces_dashboard_workspace_url: "{{ _ocp4_workload_tenant_devspaces_url }}/{{ ocp4_workload_tenant_devspaces_username }}/{{ ocp4_workload_tenant_devspaces_devworkspace_name }}"
 
     - name: Save DevSpaces user information

--- a/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
@@ -40,30 +40,13 @@
         namespace: openshift-devspaces
       register: r_devspaces_route
 
-    - name: Set DevSpaces URL fact
+    - name: Set DevSpaces dashboard URL
       ansible.builtin.set_fact:
-        _ocp4_workload_tenant_devspaces_url: "https://{{ r_devspaces_route.resources[0].spec.host }}"
-
-    - name: Get DevWorkspace to retrieve workspace URL
-      kubernetes.core.k8s_info:
-        api_version: workspace.devfile.io/v1alpha2
-        kind: DevWorkspace
-        name: "{{ ocp4_workload_tenant_devspaces_devworkspace_name }}"
-        namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
-      register: r_devworkspace
-      retries: 10
-      delay: 5
-      until:
-        - r_devworkspace.resources | length > 0
-        - r_devworkspace.resources[0].status.mainUrl is defined
-
-    - name: Set DevWorkspace dashboard URL
-      ansible.builtin.set_fact:
-        _ocp4_workload_tenant_devspaces_dashboard_workspace_url: "{{ _ocp4_workload_tenant_devspaces_url }}/{{ ocp4_workload_tenant_devspaces_username }}/{{ ocp4_workload_tenant_devspaces_devworkspace_name }}"
+        _ocp4_workload_tenant_devspaces_dashboard_url: "https://{{ r_devspaces_route.resources[0].spec.host }}"
 
     - name: Save DevSpaces user information
       agnosticd.core.agnosticd_user_info:
         data:
-          devspaces_url: "{{ _ocp4_workload_tenant_devspaces_dashboard_workspace_url }}"
+          devspaces_url: "{{ _ocp4_workload_tenant_devspaces_dashboard_url }}"
           devspaces_username: "{{ ocp4_workload_tenant_devspaces_username }}"
           devspaces_password: "{{ ocp4_workload_tenant_devspaces_user_password }}"

--- a/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
@@ -57,14 +57,14 @@
         - r_devworkspace.resources | length > 0
         - r_devworkspace.resources[0].status.mainUrl is defined
 
-    - name: Set DevWorkspace URL fact
+    - name: Set DevWorkspace URLs
       ansible.builtin.set_fact:
         _ocp4_workload_tenant_devspaces_workspace_url: "{{ r_devworkspace.resources[0].status.mainUrl }}"
+        _ocp4_workload_tenant_devspaces_dashboard_workspace_url: "{{ _ocp4_workload_tenant_devspaces_url }}/{{ ocp4_workload_tenant_devspaces_username }}/{{ ocp4_workload_tenant_devspaces_devworkspace_name }}"
 
     - name: Save DevSpaces user information
       agnosticd.core.agnosticd_user_info:
         data:
-          devspaces_url: "{{ _ocp4_workload_tenant_devspaces_url }}"
-          devspaces_workspace_url: "{{ _ocp4_workload_tenant_devspaces_workspace_url }}"
+          devspaces_url: "{{ _ocp4_workload_tenant_devspaces_dashboard_workspace_url }}"
           devspaces_username: "{{ ocp4_workload_tenant_devspaces_username }}"
           devspaces_password: "{{ ocp4_workload_tenant_devspaces_user_password }}"

--- a/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
@@ -15,6 +15,14 @@
         state: patched
         definition: "{{ lookup('template', 'namespace.yml.j2') | from_yaml }}"
 
+    # ==================================================================
+    # Setup embedded devfile mode (if enabled)
+    # ==================================================================
+
+    - name: Setup embedded devfile and create DevWorkspaceTemplate
+      ansible.builtin.include_tasks: setup_embedded_devfile.yml
+      when: ocp4_workload_tenant_devspaces_use_embedded_devfile | bool
+
     - name: Create DevWorkspace
       kubernetes.core.k8s:
         state: present

--- a/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_devspaces/tasks/workload.yml
@@ -44,9 +44,27 @@
       ansible.builtin.set_fact:
         _ocp4_workload_tenant_devspaces_url: "https://{{ r_devspaces_route.resources[0].spec.host }}"
 
+    - name: Get DevWorkspace to retrieve workspace URL
+      kubernetes.core.k8s_info:
+        api_version: workspace.devfile.io/v1alpha2
+        kind: DevWorkspace
+        name: "{{ ocp4_workload_tenant_devspaces_devworkspace_name }}"
+        namespace: "{{ ocp4_workload_tenant_devspaces_namespace }}"
+      register: r_devworkspace
+      retries: 10
+      delay: 5
+      until:
+        - r_devworkspace.resources | length > 0
+        - r_devworkspace.resources[0].status.mainUrl is defined
+
+    - name: Set DevWorkspace URL fact
+      ansible.builtin.set_fact:
+        _ocp4_workload_tenant_devspaces_workspace_url: "{{ r_devworkspace.resources[0].status.mainUrl }}"
+
     - name: Save DevSpaces user information
       agnosticd.core.agnosticd_user_info:
         data:
           devspaces_url: "{{ _ocp4_workload_tenant_devspaces_url }}"
+          devspaces_workspace_url: "{{ _ocp4_workload_tenant_devspaces_workspace_url }}"
           devspaces_username: "{{ ocp4_workload_tenant_devspaces_username }}"
           devspaces_password: "{{ ocp4_workload_tenant_devspaces_user_password }}"

--- a/roles/ocp4_workload_tenant_devspaces/templates/configmap-env.yml.j2
+++ b/roles/ocp4_workload_tenant_devspaces/templates/configmap-env.yml.j2
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ ocp4_workload_tenant_devspaces_username }}-devworkspace-env
+  namespace: {{ ocp4_workload_tenant_devspaces_namespace }}
+  labels:
+    created-by: agnosticd
+    controller.devfile.io/mount-to-devworkspace: "true"
+    controller.devfile.io/watch-configmap: "true"
+  annotations:
+    controller.devfile.io/mount-as: env
+data:
+{% for env_var in ocp4_workload_tenant_devspaces_devfile_env_vars %}
+  {{ env_var.name }}: "{{ env_var.value }}"
+{% endfor %}

--- a/roles/ocp4_workload_tenant_devspaces/templates/configmap-env.yml.j2
+++ b/roles/ocp4_workload_tenant_devspaces/templates/configmap-env.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ ocp4_workload_tenant_devspaces_username }}-devworkspace-env
+  name: devworkspace-env
   namespace: {{ ocp4_workload_tenant_devspaces_namespace }}
   labels:
     created-by: agnosticd

--- a/roles/ocp4_workload_tenant_devspaces/templates/devworkspace-template.yml.j2
+++ b/roles/ocp4_workload_tenant_devspaces/templates/devworkspace-template.yml.j2
@@ -1,0 +1,120 @@
+---
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  name: {{ ocp4_workload_tenant_devspaces_devworkspace_template_name }}
+  namespace: {{ ocp4_workload_tenant_devspaces_namespace }}
+  annotations:
+    che.eclipse.org/components-update-policy: managed
+  labels:
+    created-by: agnosticd
+spec:
+  commands:
+  - apply:
+      component: che-code-injector
+    id: init-container-command
+  - exec:
+      commandLine: nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt 2>&1 &
+      component: che-code-runtime-description
+    id: init-che-code-command
+
+  components:
+  # Che Code Injector - Initialization container
+  - container:
+      command:
+      - /entrypoint-init-container.sh
+      cpuLimit: 500m
+      cpuRequest: 30m
+      env:
+      - name: CHE_DASHBOARD_URL
+        value: {{ _devspaces_dashboard_url }}
+      - name: CHE_PLUGIN_REGISTRY_URL
+        value: {{ _devspaces_plugin_registry_url }}
+      - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+        value: {{ _devspaces_plugin_registry_internal_url }}
+      - name: CLUSTER_CONSOLE_URL
+        value: {{ _devspaces_cluster_console_url }}
+      - name: CLUSTER_CONSOLE_TITLE
+        value: OpenShift console
+      - name: OPENVSX_REGISTRY_URL
+        value: ""
+      image: {{ ocp4_workload_tenant_devspaces_che_code_image }}
+      memoryLimit: 256Mi
+      memoryRequest: 32Mi
+      sourceMapping: /projects
+      volumeMounts:
+      - name: checode
+        path: /checode
+    name: che-code-injector
+
+  # Che Code Runtime - Main VS Code editor
+  - attributes:
+      app.kubernetes.io/component: che-code-runtime
+      app.kubernetes.io/part-of: che-code.eclipse.org
+      controller.devfile.io/container-contribution: true
+    container:
+      cpuLimit: 500m
+      cpuRequest: 30m
+      endpoints:
+      - attributes:
+          cookiesAuthEnabled: true
+          discoverable: false
+          type: main
+          urlRewriteSupported: true
+        exposure: public
+        name: che-code
+        protocol: https
+        secure: true
+        targetPort: 3100
+      - attributes:
+          discoverable: false
+          urlRewriteSupported: false
+        exposure: public
+        name: code-redirect-1
+        protocol: https
+        targetPort: 13131
+      - attributes:
+          discoverable: false
+          urlRewriteSupported: false
+        exposure: public
+        name: code-redirect-2
+        protocol: https
+        targetPort: 13132
+      - attributes:
+          discoverable: false
+          urlRewriteSupported: false
+        exposure: public
+        name: code-redirect-3
+        protocol: https
+        targetPort: 13133
+      env:
+      - name: CHE_DASHBOARD_URL
+        value: {{ _devspaces_dashboard_url }}
+      - name: CHE_PLUGIN_REGISTRY_URL
+        value: {{ _devspaces_plugin_registry_url }}
+      - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+        value: {{ _devspaces_plugin_registry_internal_url }}
+      - name: CLUSTER_CONSOLE_URL
+        value: {{ _devspaces_cluster_console_url }}
+      - name: CLUSTER_CONSOLE_TITLE
+        value: OpenShift console
+      - name: OPENVSX_REGISTRY_URL
+        value: ""
+      image: {{ ocp4_workload_tenant_devspaces_udi_image }}
+      memoryLimit: 1024Mi
+      memoryRequest: 256Mi
+      sourceMapping: /projects
+      volumeMounts:
+      - name: checode
+        path: /checode
+    name: che-code-runtime-description
+
+  # Shared volume for VS Code
+  - name: checode
+    volume: {}
+
+  events:
+    postStart:
+    - init-che-code-command
+    preStart:
+    - init-container-command

--- a/roles/ocp4_workload_tenant_devspaces/templates/devworkspace.yml.j2
+++ b/roles/ocp4_workload_tenant_devspaces/templates/devworkspace.yml.j2
@@ -6,12 +6,35 @@ metadata:
   namespace: {{ ocp4_workload_tenant_devspaces_namespace }}
   labels:
     created-by: agnosticd
+    student-name: {{ ocp4_workload_tenant_devspaces_username }}
 spec:
   routingClass: che
   started: true
+
+{% if ocp4_workload_tenant_devspaces_use_embedded_devfile | bool %}
+  # Embedded devfile mode: Reference DevWorkspaceTemplate for editor
+  contributions:
+  - name: editor
+    kubernetes:
+      name: {{ ocp4_workload_tenant_devspaces_devworkspace_template_name }}
+
+  template:
+    attributes:
+      controller.devfile.io/devworkspace-config:
+        name: devworkspace-config
+        namespace: openshift-devspaces
+      controller.devfile.io/scc: {{ ocp4_workload_tenant_devspaces_scc }}
+      controller.devfile.io/storage-type: per-user
+
+    # Embedded devfile content (stripped of schemaVersion and metadata, with env vars injected)
+{{ _devfile_template_content | to_nice_yaml(indent=2) | indent(4, first=True) }}
+
+{% else %}
+  # URI-based mode (backward compatible): Reference external devfile
   contributions:
   - name: ide
     uri: {{ ocp4_workload_tenant_devspaces_devworkspace_devfile }}
+
   template:
 {% if ocp4_workload_tenant_devspaces_devworkspace_projects | default([]) | length > 0 %}
     projects:
@@ -25,3 +48,4 @@ spec:
 {% endfor %}
 {% endif %}
     components: {{ ocp4_workload_tenant_devspaces_devworkspace_components | to_json }}
+{% endif %}

--- a/roles/ocp4_workload_tenant_devspaces/templates/secret-env.yml.j2
+++ b/roles/ocp4_workload_tenant_devspaces/templates/secret-env.yml.j2
@@ -1,16 +1,17 @@
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: devworkspace-env
   namespace: {{ ocp4_workload_tenant_devspaces_namespace }}
   labels:
     created-by: agnosticd
     controller.devfile.io/mount-to-devworkspace: "true"
-    controller.devfile.io/watch-configmap: "true"
+    controller.devfile.io/watch-secret: "true"
   annotations:
     controller.devfile.io/mount-as: env
-data:
+type: Opaque
+stringData:
 {% for env_var in ocp4_workload_tenant_devspaces_devfile_env_vars %}
   {{ env_var.name }}: "{{ env_var.value }}"
 {% endfor %}


### PR DESCRIPTION
Features:
- Add optional embedded devfile mode (use_embedded_devfile flag, default: false)
- Auto-detect cluster URLs (DevSpaces dashboard, plugin registry, console)
- Fetch devfile from Git URL and embed into DevWorkspace template section
- Create DevWorkspaceTemplate for generic VS Code editor
- Support environment variable injection via ConfigMap (auto-mounted)
- Maintain backward compatibility (URI-based mode when disabled)

New files:
- tasks/setup_embedded_devfile.yml - URL detection, devfile fetching, processing
- templates/configmap-env.yml.j2 - Environment variables ConfigMap template
- templates/devworkspace-template.yml.j2 - VS Code editor template

Modified files:
- defaults/main.yml - Add embedded devfile configuration variables
- tasks/workload.yml - Include embedded devfile setup task
- tasks/remove_workload.yml - Add cleanup for DevWorkspaceTemplate and ConfigMap
- templates/devworkspace.yml.j2 - Add conditional logic for embedded vs URI mode

ConfigMap approach:
- Uses controller.devfile.io/mount-to-devworkspace label
- Uses controller.devfile.io/mount-as=env annotation
- Automatically mounts env vars to all containers in DevWorkspace