### PR TITLE
Add VS Code settings configuration for DevWorkspaces

### DIFF
--- a/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
@@ -56,7 +56,9 @@ ocp4_workload_tenant_devspaces_use_embedded_devfile: false
 ocp4_workload_tenant_devspaces_devworkspace_template_name: "che-code-{{ ocp4_workload_tenant_devspaces_username }}"
 
 # VS Code editor images (used when embedded devfile is enabled)
+# yamllint disable-line rule:line-length
 ocp4_workload_tenant_devspaces_che_code_image: "registry.redhat.io/devspaces/code-rhel9@sha256:5cd4fe568b4352bc5ef6ec0b16c3235fe515c2afb86fb076ed435cea65ea2247"
+# yamllint disable-line rule:line-length
 ocp4_workload_tenant_devspaces_udi_image: "registry.redhat.io/devspaces/udi-rhel9@sha256:024712461154d505de3180f4459363c46bc5d0fe7465d7e270108540ce8902fe"
 
 # Environment variables to inject into devfile containers (when embedded mode is enabled)

--- a/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_devspaces/defaults/main.yml
@@ -68,3 +68,12 @@ ocp4_workload_tenant_devspaces_devfile_env_vars: []
 
 # SCC attribute for container builds
 ocp4_workload_tenant_devspaces_scc: "container-build"
+
+# VS Code / che-code workspace settings (applied to all workspaces)
+# These settings are injected into the DevWorkspace attributes
+# Example settings to disable auto-save (prevents AI code fixes from being auto-accepted):
+# ocp4_workload_tenant_devspaces_vscode_settings:
+#   files.autoSave: "off"
+#   editor.formatOnSave: false
+#   editor.codeActionsOnSave: {}
+ocp4_workload_tenant_devspaces_vscode_settings: {}

--- a/roles/ocp4_workload_tenant_devspaces/templates/devworkspace.yml.j2
+++ b/roles/ocp4_workload_tenant_devspaces/templates/devworkspace.yml.j2
@@ -25,6 +25,9 @@ spec:
         namespace: openshift-devspaces
       controller.devfile.io/scc: {{ ocp4_workload_tenant_devspaces_scc }}
       controller.devfile.io/storage-type: per-user
+{% if ocp4_workload_tenant_devspaces_vscode_settings | default({}) | length > 0 %}
+      che-code.workspace.settings: {{ ocp4_workload_tenant_devspaces_vscode_settings | to_json }}
+{% endif %}
 
     # Embedded devfile content (stripped of schemaVersion and metadata, with env vars injected)
 {{ _devfile_template_content | to_nice_yaml(indent=2) | indent(4, first=True) }}
@@ -36,6 +39,10 @@ spec:
     uri: {{ ocp4_workload_tenant_devspaces_devworkspace_devfile }}
 
   template:
+{% if ocp4_workload_tenant_devspaces_vscode_settings | default({}) | length > 0 %}
+    attributes:
+      che-code.workspace.settings: {{ ocp4_workload_tenant_devspaces_vscode_settings | to_json }}
+{% endif %}
 {% if ocp4_workload_tenant_devspaces_devworkspace_projects | default([]) | length > 0 %}
     projects:
 {% for project in ocp4_workload_tenant_devspaces_devworkspace_projects %}


### PR DESCRIPTION
Adds ability to configure VS Code/che-code workspace settings via DevWorkspace attributes for both embedded and URI-based modes.

Key changes:
- New variable: ocp4_workload_tenant_devspaces_vscode_settings
- Default settings disable auto-save to prevent AI code fixes from being auto-accepted without user review
- Settings injected into both embedded and URI-based DevWorkspace modes via che-code.workspace.settings attribute

Fixes issue where MTA extension settings persisted across tenant recreations due to browser localStorage caching.