### PR TITLE
add: ability to provide arbitrary metadata for the created namespace

### DIFF
--- a/roles/ocp4_workload_tenant_namespace/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_namespace/defaults/main.yml
@@ -9,6 +9,20 @@ ocp4_workload_tenant_namespace_username: "user-{{ guid }}"
 # RBAC role bound to the user in each namespace.
 ocp4_workload_tenant_namespace_role: admin
 
+# Metadata to apply to the namespace, e.g.
+# ocp4_workload_tenant_namespace_metadata:
+#   labels:
+#     opendatahub.io/dashboard: "true"
+#     kueue-managed: "true"
+#     kueue.openshift.io/managed: "true"
+#   annotations:
+#     openshift.io/display-name: "{{ ocp4_workload_tenant_namespace_username | ansible.builtin.title }} Project"
+ocp4_workload_tenant_namespace_metadata: {}
+ocp4_workload_tenant_namespace_default_metadata:
+  labels:
+    created-by: agnosticd
+    tenant: "{{ ocp4_workload_tenant_namespace_username }}"
+
 # Namespaces to create. Leave empty to create a single namespace named after
 # the user (no suffix). Each entry requires 'suffix'. 'quota' and
 # 'limit_range' override the role defaults below and are only used when

--- a/roles/ocp4_workload_tenant_namespace/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_namespace/tasks/workload.yml
@@ -48,11 +48,10 @@
     definition:
       apiVersion: v1
       kind: Namespace
-      metadata:
-        name: "{{ item.name }}"
-        labels:
-          created-by: agnosticd
-          tenant: "{{ ocp4_workload_tenant_namespace_username }}"
+      metadata: >-
+        {{ ocp4_workload_tenant_namespace_metadata
+          | ansible.builtin.combine(ocp4_workload_tenant_namespace_default_metadata, recursive=True)
+          | ansible.builtin.combine({'name': item.name}) }}
   loop: "{{ _tenant_namespaces }}"
   loop_control:
     label: "{{ item.name }}"


### PR DESCRIPTION
This PR will allow the role to:

- Accept user metadata such as arbitrary annotations or labels from the workload to apply to the namespace
- Force override the metadata with a set of defaults (including the previously applied labels), replacing any identically named labels from the user-provided metadata
- Apply the name last of all, providing complete control over that name from the role