### PR TITLE
fix: make destroy workflows idempotent (handle already-deleted resources)

### DIFF
--- a/roles/ocp4_workload_tenant_gitea_user/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_gitea_user/tasks/remove_workload.yml
@@ -16,7 +16,7 @@
     - name: Validate Gitea admin setup is complete
       ansible.builtin.assert:
         that:
-        - r_gitea.resources[0].status.adminSetupComplete | bool
+          - r_gitea.resources[0].status.adminSetupComplete | bool
         fail_msg: Gitea admin setup is not complete yet.
 
     - name: Set Gitea connection facts
@@ -39,7 +39,7 @@
         force_basic_auth: true
         validate_certs: false
         status_code:
-        - 200
+          - 200
       register: r_gitea_user_repos
 
     - name: Delete all repositories for Gitea user
@@ -54,8 +54,8 @@
         force_basic_auth: true
         validate_certs: false
         status_code:
-        - 204
-        - 404
+          - 204
+          - 404
       loop: "{{ r_gitea_user_repos.json.data | default([]) }}"
       loop_control:
         label: "{{ item.name }}"
@@ -71,5 +71,5 @@
         force_basic_auth: true
         validate_certs: false
         status_code:
-        - 204
-        - 404
+          - 204
+          - 404

--- a/roles/ocp4_workload_tenant_gitea_user/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_gitea_user/tasks/remove_workload.yml
@@ -9,65 +9,67 @@
     name: "{{ ocp4_workload_tenant_gitea_user_instance }}"
     namespace: "{{ ocp4_workload_tenant_gitea_user_namespace }}"
   register: r_gitea
-  failed_when: r_gitea.resources | length == 0
 
-- name: Validate Gitea admin setup is complete
-  ansible.builtin.assert:
-    that:
-    - r_gitea.resources[0].status.adminSetupComplete | bool
-    fail_msg: Gitea admin setup is not complete yet.
+- name: Clean up Gitea user and repositories
+  when: r_gitea.resources | length > 0
+  block:
+    - name: Validate Gitea admin setup is complete
+      ansible.builtin.assert:
+        that:
+        - r_gitea.resources[0].status.adminSetupComplete | bool
+        fail_msg: Gitea admin setup is not complete yet.
 
-- name: Set Gitea connection facts
-  ansible.builtin.set_fact:
-    _ocp4_workload_tenant_gitea_user_admin_user: >-
-      {{ r_gitea.resources[0].spec.giteaAdminUser }}
-    _ocp4_workload_tenant_gitea_user_admin_password: >-
-      {{ r_gitea.resources[0].status.adminPassword }}
-    _ocp4_workload_tenant_gitea_user_route: >-
-      {{ r_gitea.resources[0].status.giteaRoute }}
+    - name: Set Gitea connection facts
+      ansible.builtin.set_fact:
+        _ocp4_workload_tenant_gitea_user_admin_user: >-
+          {{ r_gitea.resources[0].spec.giteaAdminUser }}
+        _ocp4_workload_tenant_gitea_user_admin_password: >-
+          {{ r_gitea.resources[0].status.adminPassword }}
+        _ocp4_workload_tenant_gitea_user_route: >-
+          {{ r_gitea.resources[0].status.giteaRoute }}
 
-- name: Get all repositories for Gitea user
-  ansible.builtin.uri:
-    url: >-
-      {{ _ocp4_workload_tenant_gitea_user_route }}/api/v1/repos/search?owner={{
-      ocp4_workload_tenant_gitea_user_username }}&limit=50
-    method: GET
-    url_username: "{{ _ocp4_workload_tenant_gitea_user_admin_user }}"
-    url_password: "{{ _ocp4_workload_tenant_gitea_user_admin_password }}"
-    force_basic_auth: true
-    validate_certs: false
-    status_code:
-    - 200
-  register: r_gitea_user_repos
+    - name: Get all repositories for Gitea user
+      ansible.builtin.uri:
+        url: >-
+          {{ _ocp4_workload_tenant_gitea_user_route }}/api/v1/repos/search?owner={{
+          ocp4_workload_tenant_gitea_user_username }}&limit=50
+        method: GET
+        url_username: "{{ _ocp4_workload_tenant_gitea_user_admin_user }}"
+        url_password: "{{ _ocp4_workload_tenant_gitea_user_admin_password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code:
+        - 200
+      register: r_gitea_user_repos
 
-- name: Delete all repositories for Gitea user
-  when: r_gitea_user_repos.json.data | default([]) | length > 0
-  ansible.builtin.uri:
-    url: >-
-      {{ _ocp4_workload_tenant_gitea_user_route }}/api/v1/repos/{{
-      ocp4_workload_tenant_gitea_user_username }}/{{ item.name }}
-    method: DELETE
-    url_username: "{{ _ocp4_workload_tenant_gitea_user_admin_user }}"
-    url_password: "{{ _ocp4_workload_tenant_gitea_user_admin_password }}"
-    force_basic_auth: true
-    validate_certs: false
-    status_code:
-    - 204
-    - 404
-  loop: "{{ r_gitea_user_repos.json.data | default([]) }}"
-  loop_control:
-    label: "{{ item.name }}"
+    - name: Delete all repositories for Gitea user
+      when: r_gitea_user_repos.json.data | default([]) | length > 0
+      ansible.builtin.uri:
+        url: >-
+          {{ _ocp4_workload_tenant_gitea_user_route }}/api/v1/repos/{{
+          ocp4_workload_tenant_gitea_user_username }}/{{ item.name }}
+        method: DELETE
+        url_username: "{{ _ocp4_workload_tenant_gitea_user_admin_user }}"
+        url_password: "{{ _ocp4_workload_tenant_gitea_user_admin_password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code:
+        - 204
+        - 404
+      loop: "{{ r_gitea_user_repos.json.data | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}"
 
-- name: Delete Gitea user
-  ansible.builtin.uri:
-    url: >-
-      {{ _ocp4_workload_tenant_gitea_user_route }}/api/v1/admin/users/{{
-      ocp4_workload_tenant_gitea_user_username }}
-    method: DELETE
-    url_username: "{{ _ocp4_workload_tenant_gitea_user_admin_user }}"
-    url_password: "{{ _ocp4_workload_tenant_gitea_user_admin_password }}"
-    force_basic_auth: true
-    validate_certs: false
-    status_code:
-    - 204
-    - 404
+    - name: Delete Gitea user
+      ansible.builtin.uri:
+        url: >-
+          {{ _ocp4_workload_tenant_gitea_user_route }}/api/v1/admin/users/{{
+          ocp4_workload_tenant_gitea_user_username }}
+        method: DELETE
+        url_username: "{{ _ocp4_workload_tenant_gitea_user_admin_user }}"
+        url_password: "{{ _ocp4_workload_tenant_gitea_user_admin_password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code:
+        - 204
+        - 404

--- a/roles/ocp4_workload_tenant_gitea_user/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_gitea_user/tasks/remove_workload.yml
@@ -53,6 +53,7 @@
     validate_certs: false
     status_code:
     - 204
+    - 404
   loop: "{{ r_gitea_user_repos.json.data | default([]) }}"
   loop_control:
     label: "{{ item.name }}"

--- a/roles/ocp4_workload_tenant_keycloak_user/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_keycloak_user/tasks/remove_workload.yml
@@ -63,7 +63,9 @@
     validate_certs: false
     headers:
       Authorization: "Bearer {{ r_keycloak_token.json.access_token }}"
-    status_code: 204
+    status_code:
+    - 204
+    - 404
 
 # -----------------------------------------------
 # OCP Identity and User cleanup


### PR DESCRIPTION
## Summary

Multiple `remove_workload.yml` roles fail during destroy if resources have already been cleaned up by a prior attempt, manual intervention, or race conditions. This PR makes the destroy workflow idempotent across three roles.

### Changes

**1. `ocp4_workload_tenant_gitea_user` — repo deletion 404 handling**
The "Delete all repositories" task only accepted `status_code: [204]`, failing with 404 when the tenant user was already deleted. The Gitea admin-authenticated search can still return repos for a deleted user, but the DELETE endpoint returns 404 since the user path no longer resolves. Added `404` to match the pattern already used by the "Delete Gitea user" task.

**2. `ocp4_workload_tenant_gitea_user` — Gitea CR gone handling**
`failed_when: r_gitea.resources | length == 0` caused the entire role to abort if the Gitea custom resource was already deleted, blocking all downstream cleanup. Replaced with a `when` guard on a block — if the Gitea CR is gone, the block is skipped and destroy succeeds.

**3. `ocp4_workload_tenant_keycloak_user` — Keycloak user deletion 404 handling**
Same class of bug: `status_code: 204` on the Keycloak user DELETE fails if the user was already removed. Changed to `[204, 404]` for idempotent destroy.

### Impact

These bugs were causing `destroy-failed` subjects to accumulate:
- 3 subjects stuck for `summit-2026.lb2010-rhads-ols-modernize-tenant.dev` (Gitea 404)
- Potential for same failures in any tenant config using these roles

### Audit

Reviewed all 9 roles with `remove_workload.yml` in this collection:
- `ns_example` — no-op, safe
- `ns_private_lmaas` — `state: absent`, inherently idempotent
- `ocp4_workload_tenant_devspaces` — `state: absent` + `ignore_errors`, safe
- `ocp4_workload_tenant_gitea` — `state: absent` + `ignore_errors`, safe
- `ocp4_workload_tenant_namespace` — idempotent by design
- `ocp4_workload_tenant_openshift_gitops` — proper `when` guards, safe
- `ocp4_workload_tenant_quay` — DELETE already accepts `[200, 204, 404]`, safe
  - Note: `k8s_info` with `failed_when: resources == 0` for QuayRegistry/admin secret could still abort if Quay is gone (same class of issue, not fixed here to limit scope)

## Test plan

- [ ] Verify destroy succeeds when Gitea user already deleted (404 on repo delete)
- [ ] Verify destroy succeeds when Gitea CR already removed (block skipped)
- [ ] Verify destroy succeeds when Keycloak user already deleted (404 on user delete)
- [ ] Verify normal destroy still works (all resources present)