### PR TITLE
rework metadata to enable per-suffix application

### DIFF
--- a/roles/ocp4_workload_tenant_namespace/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_namespace/defaults/main.yml
@@ -10,18 +10,12 @@ ocp4_workload_tenant_namespace_username: "user-{{ guid }}"
 ocp4_workload_tenant_namespace_role: admin
 
 # Metadata to apply to the namespace, e.g.
-# ocp4_workload_tenant_namespace_metadata:
+# ocp4_workload_tenant_namespace_default_metadata:
 #   labels:
 #     opendatahub.io/dashboard: "true"
 #     kueue-managed: "true"
 #     kueue.openshift.io/managed: "true"
-#   annotations:
-#     openshift.io/display-name: "{{ ocp4_workload_tenant_namespace_username | ansible.builtin.title }} Project"
-ocp4_workload_tenant_namespace_metadata: {}
-ocp4_workload_tenant_namespace_default_metadata:
-  labels:
-    created-by: agnosticd
-    tenant: "{{ ocp4_workload_tenant_namespace_username }}"
+ocp4_workload_tenant_namespace_default_metadata: {}
 
 # Namespaces to create. Leave empty to create a single namespace named after
 # the user (no suffix). Each entry requires 'suffix'. 'quota' and
@@ -43,7 +37,12 @@ ocp4_workload_tenant_namespace_default_metadata:
 #     defaultRequest:
 #       cpu: 500m
 #       memory: 1Gi
-# - suffix: mydb   # no quota/limit_range — uses role defaults
+#   metadata:
+#     labels:
+#       opendatahub.io/dashboard: "true"
+#     annotations:
+#       openshift.io/display-name: "My App"
+# - suffix: mydb   # no quota/limit_range/metadata — uses role defaults
 ocp4_workload_tenant_namespace_suffixes: []
 
 # Use an OpenShift ClusterResourceQuota (CRQ) scoped to the tenant label.

--- a/roles/ocp4_workload_tenant_namespace/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_namespace/tasks/workload.yml
@@ -22,6 +22,7 @@
       - name: "{{ ocp4_workload_tenant_namespace_username }}"
         quota: "{{ ocp4_workload_tenant_namespace_default_quota }}"
         limit_range: "{{ ocp4_workload_tenant_namespace_default_limit_range }}"
+        metadata: "{{ ocp4_workload_tenant_namespace_default_metadata }}"
 
 - name: Build namespace list — from suffix entries
   when: ocp4_workload_tenant_namespace_suffixes | length > 0
@@ -30,7 +31,17 @@
       {{ _tenant_namespaces + [{
            'name': ocp4_workload_tenant_namespace_username ~ '-' ~ item.suffix,
            'quota': item.quota | default(ocp4_workload_tenant_namespace_default_quota),
-           'limit_range': item.limit_range | default(ocp4_workload_tenant_namespace_default_limit_range)
+           'limit_range': item.limit_range | default(ocp4_workload_tenant_namespace_default_limit_range),
+           'metadata': (item.metadata | default({}))
+              | ansible.builtin.combine(ocp4_workload_tenant_namespace_default_metadata, recursive=True)
+              | ansible.builtin.combine(
+                  {
+                    "labels": {
+                      "created-by": "agnosticd",
+                      "tenant": ocp4_workload_tenant_namespace_username
+                    }
+                  }
+                recursive=True),
          }] }}
   loop: "{{ ocp4_workload_tenant_namespace_suffixes }}"
   loop_control:
@@ -48,10 +59,7 @@
     definition:
       apiVersion: v1
       kind: Namespace
-      metadata: >-
-        {{ ocp4_workload_tenant_namespace_metadata
-          | ansible.builtin.combine(ocp4_workload_tenant_namespace_default_metadata, recursive=True)
-          | ansible.builtin.combine({'name': item.name}) }}
+      metadata: "{{ item.metadata | ansible.builtin.combine({'name': item.name}) }}"
   loop: "{{ _tenant_namespaces }}"
   loop_control:
     label: "{{ item.name }}"

--- a/roles/ocp4_workload_tenant_namespace/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_namespace/tasks/workload.yml
@@ -40,8 +40,9 @@
                       "created-by": "agnosticd",
                       "tenant": ocp4_workload_tenant_namespace_username
                     }
-                  }
-                recursive=True),
+                  },
+                  recursive=True
+                ),
          }] }}
   loop: "{{ ocp4_workload_tenant_namespace_suffixes }}"
   loop_control:


### PR DESCRIPTION
In the previous PR I opened, I was looking at agnosticv roles and got enough of what I wanted hacked in that it worked out fine. Now that I've been working w/ NSaaS a bit more on some other CIs, I realized that what I really want is per-namespace-suffix metadata, with the option to override the defaults, and figured I should make it so there's no var that an agnosticv user could provide to override the role's original hard coded labels (because these are probably being used for tracking elsewhere...).

This change moves to per-suffix metadata, user-provided defaults for all namespace suffixes, and no way to override the `created-by` or `tenant` labels that the role applies.

I don't think uptake on my last PR extends beyond me (yet) so this should be minimally disruptive.