### PR TITLE
[ocp4_workload_tenant_namespace] Document pods quota key support

### DIFF
--- a/roles/ocp4_workload_tenant_namespace/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_namespace/defaults/main.yml
@@ -30,6 +30,7 @@ ocp4_workload_tenant_namespace_default_metadata: {}
 #     limits.memory: 8Gi
 #     requests.memory: 8Gi
 #     requests.storage: 20Gi
+#     pods: "50"          # optional — caps total pod count across all namespaces
 #   limit_range:
 #     default:
 #       cpu: "2"
@@ -56,6 +57,11 @@ ocp4_workload_tenant_namespace_use_cluster_quota: true
 # Used as ClusterResourceQuota hard limits when use_cluster_quota is true,
 # or as the default per-namespace ResourceQuota when use_cluster_quota is false
 # and no per-namespace quota is defined in the suffix entry.
+#
+# Any valid Kubernetes ResourceQuota hard limit key is accepted, including:
+#   pods — caps the total number of pods across all tenant namespaces.
+#   Recommended for multi-tenant clusters to prevent runaway pod creation.
+#   Example: pods: "50"
 ocp4_workload_tenant_namespace_default_quota:
   limits.cpu: "4"
   requests.cpu: "4"


### PR DESCRIPTION
## Summary

- Documents that `pods` is a valid key in `ocp4_workload_tenant_namespace_default_quota` for capping total pod count across all tenant namespaces
- No code changes — the dict is already passed through directly as `hard` limits to both `ClusterResourceQuota` and `ResourceQuota`
- Adds a `pods: "50"` example comment to the per-suffix quota block and a note to the default quota variable

## Motivation

Multi-tenant lab clusters need a pod count ceiling to prevent runaway pod creation (e.g. a student scaling to thousands of small pods). The existing CPU/memory limits don't prevent this since very small pods can be created in large numbers within the resource budget.

## Usage

```yaml
ocp4_workload_tenant_namespace_default_quota:
  limits.cpu: "10"
  requests.cpu: "5"
  limits.memory: 10Gi
  requests.memory: 5Gi
  requests.storage: 100Gi
  pods: "50"
```