### PR TITLE
ocp4_workload_tenant_rhacs: Add API token creation and APIToken creator role

### DIFF
--- a/roles/ocp4_workload_tenant_rhacs/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_rhacs/defaults/main.yml
@@ -14,6 +14,11 @@ ocp4_workload_tenant_rhacs_username: "user-{{ guid }}"
 #   Scope Manager, Sensor Creator, Vulnerability Management Approver
 ocp4_workload_tenant_rhacs_roles:
 - Analyst
+- APIToken creator
 
 # Key used for user matching in RHACS (typically "name" or "email")
 ocp4_workload_tenant_rhacs_user_attribute: "name"
+
+# API token creation
+ocp4_workload_tenant_rhacs_create_api_token: true
+ocp4_workload_tenant_rhacs_api_token_expiration_days: 14

--- a/roles/ocp4_workload_tenant_rhacs/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_tenant_rhacs/tasks/remove_workload.yml
@@ -91,3 +91,37 @@
     validate_certs: false
     status_code: 200
   register: r_rhacs_groupsbatch_remove
+
+- name: List RHACS API tokens
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_tenant_rhacs_central_route }}/v1/apitokens"
+    method: GET
+    user: admin
+    password: "{{ _ocp4_workload_tenant_rhacs_admin_password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: 200
+  register: r_rhacs_api_tokens
+
+- name: Find tokens belonging to user
+  ansible.builtin.set_fact:
+    _ocp4_workload_tenant_rhacs_user_tokens: >-
+      {{
+        r_rhacs_api_tokens.json.tokens | default([])
+        | selectattr('name', 'equalto', ocp4_workload_tenant_rhacs_username)
+        | list
+      }}
+
+- name: Revoke user's API tokens
+  when: _ocp4_workload_tenant_rhacs_user_tokens | length > 0
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_tenant_rhacs_central_route }}/v1/apitokens/revoke/{{ item.id }}"
+    method: PATCH
+    user: admin
+    password: "{{ _ocp4_workload_tenant_rhacs_admin_password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: 200
+  loop: "{{ _ocp4_workload_tenant_rhacs_user_tokens }}"
+  loop_control:
+    label: "{{ item.name }} ({{ item.id }})"

--- a/roles/ocp4_workload_tenant_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_tenant_rhacs/tasks/workload.yml
@@ -81,9 +81,45 @@
     status_code: 200
   register: r_rhacs_groupsbatch
 
+- name: Compute API token expiration timestamp
+  when: ocp4_workload_tenant_rhacs_create_api_token | bool
+  ansible.builtin.set_fact:
+    _ocp4_workload_tenant_rhacs_token_expiration: >-
+      {{
+        '%Y-%m-%dT%H:%M:%SZ'
+        | strftime(lookup('pipe', 'date -u +%s') | int
+          + (ocp4_workload_tenant_rhacs_api_token_expiration_days | int * 86400))
+      }}
+
+- name: Create RHACS API token for user
+  when: ocp4_workload_tenant_rhacs_create_api_token | bool
+  ansible.builtin.uri:
+    url: "{{ _ocp4_workload_tenant_rhacs_central_route }}/v1/apitokens/generate"
+    body:
+      name: "{{ ocp4_workload_tenant_rhacs_username }}"
+      roles:
+      - Analyst
+      expiration: "{{ _ocp4_workload_tenant_rhacs_token_expiration }}"
+    method: POST
+    user: admin
+    password: "{{ _ocp4_workload_tenant_rhacs_admin_password }}"
+    body_format: json
+    force_basic_auth: true
+    validate_certs: false
+    status_code: 200
+  register: r_rhacs_api_token
+  no_log: true
+
 - name: Save user data
   agnosticd.core.agnosticd_user_info:
     data:
       rhacs_username: "{{ ocp4_workload_tenant_rhacs_username }}"
       rhacs_roles: "{{ ocp4_workload_tenant_rhacs_roles | join(', ') }}"
       rhacs_route: "{{ _ocp4_workload_tenant_rhacs_central_route }}"
+
+- name: Save RHACS API token
+  when: ocp4_workload_tenant_rhacs_create_api_token | bool
+  agnosticd.core.agnosticd_user_info:
+    data:
+      rhacs_api_token: "{{ r_rhacs_api_token.json.token }}"
+  no_log: true


### PR DESCRIPTION
## Summary
- Add `APIToken creator` to default RHACS roles so users can create their own tokens via the UI
- Automatically generate a long-lived (14-day) API token during provisioning via `POST /v1/apitokens/generate` and save it as `rhacs_api_token` in `agnosticd_user_info`
- Revoke user's API tokens during teardown via the RHACS apitokens API

## New Variables
- `ocp4_workload_tenant_rhacs_create_api_token` (default: `true`) — toggle API token creation
- `ocp4_workload_tenant_rhacs_api_token_expiration_days` (default: `14`) — token TTL in days

## Test plan
- [ ] Deploy against a cluster with RHACS and verify user gets both `Analyst` and `APIToken creator` roles
- [ ] Verify API token is created and returned in `agnosticd_user_info`
- [ ] Test token works for RHACS API calls (e.g., `GET /v1/alerts` with bearer token)
- [ ] Run `remove_workload` and verify token is revoked
- [ ] Test with `ocp4_workload_tenant_rhacs_create_api_token: false` to confirm token tasks are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)