### PR TITLE
feat(keycloak-user): support adding tenant users to realm groups

### DIFF
--- a/roles/ocp4_workload_tenant_keycloak_user/defaults/main.yml
+++ b/roles/ocp4_workload_tenant_keycloak_user/defaults/main.yml
@@ -11,3 +11,11 @@ ocp4_workload_tenant_keycloak_user_password: ""
 ocp4_workload_tenant_keycloak_user_keycloak_namespace: keycloak
 ocp4_workload_tenant_keycloak_user_keycloak_realm: sso
 ocp4_workload_tenant_keycloak_user_keycloak_admin_secret: keycloak-initial-admin
+
+# Groups to add the user to (by group name).
+# Groups must already exist in the realm (e.g. created by the realm import).
+# Example:
+#   ocp4_workload_tenant_keycloak_user_groups:
+#     - users
+#     - developers
+ocp4_workload_tenant_keycloak_user_groups: []

--- a/roles/ocp4_workload_tenant_keycloak_user/tasks/create_keycloak_user.yml
+++ b/roles/ocp4_workload_tenant_keycloak_user/tasks/create_keycloak_user.yml
@@ -78,3 +78,35 @@
       temporary: false
       value: "{{ ocp4_workload_tenant_keycloak_user_password }}"
     status_code: 204
+
+- name: Add user to Keycloak groups
+  when: ocp4_workload_tenant_keycloak_user_groups | length > 0
+  block:
+    - name: Look up group IDs
+      ansible.builtin.uri:
+        url: >-
+          {{ _ocp4_workload_tenant_keycloak_user_keycloak_host }}/admin/realms/{{
+          ocp4_workload_tenant_keycloak_user_keycloak_realm }}/groups?search={{ item }}&exact=true
+        method: GET
+        validate_certs: false
+        headers:
+          Authorization: "Bearer {{ r_keycloak_token.json.access_token }}"
+      register: r_keycloak_groups
+      loop: "{{ ocp4_workload_tenant_keycloak_user_groups }}"
+
+    - name: Add user to groups
+      ansible.builtin.uri:
+        url: >-
+          {{ _ocp4_workload_tenant_keycloak_user_keycloak_host }}/admin/realms/{{
+          ocp4_workload_tenant_keycloak_user_keycloak_realm }}/users/{{
+          r_keycloak_user.json[0].id }}/groups/{{ item.json[0].id }}
+        method: PUT
+        validate_certs: false
+        headers:
+          Authorization: "Bearer {{ r_keycloak_token.json.access_token }}"
+          Content-Type: application/json
+        status_code: [204, 409]
+      loop: "{{ r_keycloak_groups.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: item.json | length > 0


### PR DESCRIPTION
Add optional ocp4_workload_tenant_keycloak_user_groups variable. When set, the role adds the user to the specified Keycloak groups after creation. Groups must already exist in the realm.

Use case: RHDH RBAC policies are bound to group:default/users, so tenant users need to be in the 'users' group for catalog access.